### PR TITLE
Add Polls Hub, Poll‑Go entry flow and task token support

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -21,6 +21,7 @@
       <button class="btn" id="btnPollsHub">
           <span class="only-desktop">Centrum sondaży 📊</span>
           <span class="only-mobile">📊</span>
+          <span class="pollsBadge" id="pollsHubBadge" aria-hidden="true"></span>
       </button>
 
       <button class="btn" id="btnBases">

--- a/css/builder.css
+++ b/css/builder.css
@@ -542,14 +542,26 @@ body.builder-body {
   position: relative;
 }
 
-#btnPollsHub.hasDot::after{
-  content: "";
+#btnPollsHub .pollsBadge{
+  display: none;
   position: absolute;
   right: 6px;
   top: 6px;
-  width: 8px;
-  height: 8px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
   border-radius: 999px;
-  background: #ff3b30; /* iOS red dot */
-  box-shadow: 0 0 10px rgba(255,59,48,.55);
+  background: rgba(255,234,166,.2);
+  border: 1px solid rgba(255,234,166,.5);
+  color: var(--gold);
+  font-size: 10px;
+  font-weight: 1000;
+  line-height: 1;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 0 10px rgba(255,234,166,.35);
+}
+
+#btnPollsHub.hasBadge .pollsBadge{
+  display: inline-flex;
 }

--- a/css/poll-go.css
+++ b/css/poll-go.css
@@ -1,0 +1,51 @@
+/* css/poll-go.css */
+body.poll-go-body {
+  min-height: 100vh;
+  background: var(--bg);
+  color: #fff;
+}
+
+.poll-go-card {
+  border-radius: 22px;
+  border: 1px solid var(--line);
+  background: var(--card);
+  padding: 20px;
+  box-shadow: 0 24px 60px rgba(0,0,0,.45);
+}
+
+.poll-go-title {
+  font-weight: 1000;
+  font-size: 20px;
+  letter-spacing: .06em;
+  margin-bottom: 6px;
+  color: var(--gold);
+}
+
+.poll-go-sub {
+  opacity: .85;
+  line-height: 1.45;
+}
+
+.poll-go-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.poll-go-email {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.poll-go-email .inp {
+  flex: 1 1 200px;
+}
+
+.poll-go-hint {
+  margin-top: 12px;
+  font-size: 12px;
+  opacity: .7;
+}

--- a/css/polls-hub.css
+++ b/css/polls-hub.css
@@ -1,0 +1,308 @@
+/* css/polls-hub.css */
+body.polls-hub-body {
+  min-height: 100vh;
+  background: var(--bg);
+  color: #fff;
+}
+
+.topbar .left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hub-tabs .tabs-strip {
+  gap: 16px;
+}
+
+.hub-tab-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: rgba(255,234,166,.18);
+  border: 1px solid rgba(255,234,166,.45);
+  color: var(--gold);
+  font-size: 11px;
+  font-weight: 1000;
+  margin-left: 8px;
+}
+
+.hub-card {
+  padding: 16px;
+}
+
+.hub-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.hub-col {
+  display: flex;
+  flex-direction: column;
+  min-height: 420px;
+}
+
+.hub-col-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.hub-col-title {
+  font-weight: 1000;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+
+.hub-col-hint {
+  font-size: 12px;
+  opacity: .75;
+}
+
+.hub-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.hub-controls .inp.sm {
+  font-size: 12px;
+  padding: 7px 8px;
+}
+
+.hub-toggle {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.hub-toggle .btn.active {
+  border-color: rgba(255,234,166,.45);
+  background: rgba(255,234,166,.12);
+  color: var(--gold);
+}
+
+.hub-list {
+  display: grid;
+  gap: 10px;
+  min-height: 80px;
+}
+
+.hub-item {
+  border-radius: 16px;
+  border: 1px solid rgba(255,255,255,.12);
+  padding: 12px 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  cursor: pointer;
+  transition: transform .08s ease, box-shadow .2s ease;
+}
+
+.hub-item:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 26px rgba(0,0,0,.35);
+}
+
+.hub-item.selected {
+  outline: 2px solid rgba(255,234,166,.45);
+}
+
+.hub-item .hub-item-title {
+  font-weight: 900;
+  letter-spacing: .04em;
+}
+
+.hub-item .hub-item-sub {
+  font-size: 12px;
+  opacity: .75;
+}
+
+.hub-item-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.hub-item.poll-draft {
+  background: rgba(80,80,80,.28);
+}
+
+.hub-item.poll-draft-ready {
+  background: rgba(255,80,80,.2);
+}
+
+.hub-item.poll-open-empty {
+  background: rgba(255,145,0,.2);
+}
+
+.hub-item.poll-open-active {
+  background: rgba(255,200,40,.2);
+}
+
+.hub-item.poll-open-good {
+  background: rgba(70,190,120,.2);
+}
+
+.hub-item.poll-closed {
+  background: rgba(80,160,255,.2);
+}
+
+.hub-item.task-pending {
+  background: rgba(70,190,120,.2);
+}
+
+.hub-item.task-done {
+  background: rgba(80,160,255,.2);
+}
+
+.hub-item.sub-pending {
+  background: rgba(255,200,40,.22);
+}
+
+.hub-item.sub-active {
+  background: rgba(70,190,120,.22);
+}
+
+.hub-item.sub-declined {
+  background: rgba(255,90,90,.22);
+}
+
+.hub-item .btn.xs {
+  padding: 4px 6px;
+  border-radius: 10px;
+}
+
+.hub-invite {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.hub-invite .inp {
+  flex: 1 1 220px;
+}
+
+.hub-tab-panel {
+  display: none;
+}
+
+.hub-tab-panel.active {
+  display: block;
+}
+
+.hub-mobile {
+  display: none;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.hub-empty {
+  padding: 18px;
+  border-radius: 16px;
+  border: 1px dashed rgba(255,255,255,.14);
+  opacity: .75;
+  text-align: center;
+}
+
+.hub-share-list {
+  margin-top: 12px;
+  display: grid;
+  gap: 8px;
+}
+
+.hub-share-item {
+  display: grid;
+  grid-template-columns: 24px 1fr auto;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,.12);
+  background: rgba(255,255,255,.05);
+}
+
+.hub-share-status {
+  font-size: 11px;
+  opacity: .75;
+}
+
+.hub-modal-actions {
+  margin-top: 14px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.hub-modal-msg {
+  font-size: 12px;
+  opacity: .8;
+}
+
+.hub-details {
+  display: grid;
+  grid-template-columns: 1fr 1fr 180px;
+  gap: 14px;
+  margin-top: 14px;
+}
+
+.hub-details-head {
+  font-weight: 900;
+  margin-bottom: 8px;
+  letter-spacing: .04em;
+}
+
+.hub-details-list {
+  display: grid;
+  gap: 8px;
+  max-height: 340px;
+  overflow: auto;
+  padding-right: 6px;
+}
+
+.hub-details-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,.12);
+  background: rgba(255,255,255,.05);
+}
+
+.hub-anon-count {
+  font-size: 28px;
+  font-weight: 1000;
+  color: var(--gold);
+}
+
+@media (max-width: 900px) {
+  .hub-desktop {
+    display: none;
+  }
+
+  .hub-mobile {
+    display: flex;
+  }
+
+  .hub-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hub-details {
+    grid-template-columns: 1fr;
+  }
+}

--- a/js/pages/builder.js
+++ b/js/pages/builder.js
@@ -30,6 +30,7 @@ const btnManual = document.getElementById("btnManual");
 const btnLogoEditor = document.getElementById("btnLogoEditor");
 const btnBases = document.getElementById("btnBases");
 const btnPollsHub = document.getElementById("btnPollsHub");
+const pollsHubBadge = document.getElementById("pollsHubBadge");
 
 const btnExport = document.getElementById("btnExport");
 const btnImport = document.getElementById("btnImport");
@@ -714,18 +715,21 @@ document.addEventListener("DOMContentLoaded", async () => {
   async function refreshPollsHubDot(){
     // dot ma się pokazać, gdy są aktywne zadania / zaproszenia
     try{
-      const { data, error } = await sb().rpc("polls_hub_overview");
+      const { data, error } = await sb().rpc("polls_badge_get");
       if (error) throw error;
   
       const row = Array.isArray(data) ? data[0] : data;
-      const tasks = Number(row?.tasks_active ?? row?.tasks ?? 0);
-      const invites = Number(row?.invites_pending ?? row?.invites ?? 0);
-  
-      const hasNew = (tasks + invites) > 0;
-      btnPollsHub?.classList.toggle("hasDot", hasNew);
+      const tasks = Number(row?.tasks_pending ?? 0);
+      const invites = Number(row?.subs_pending ?? 0);
+      const total = tasks + invites;
+      const text = total > 99 ? "99+" : String(total);
+      const hasNew = total > 0;
+      btnPollsHub?.classList.toggle("hasBadge", hasNew);
+      if (pollsHubBadge) pollsHubBadge.textContent = hasNew ? text : "";
     } catch (e){
       // jak RPC nie istnieje / nie zwróci pól — nie blokujemy UI
-      btnPollsHub?.classList.remove("hasDot");
+      btnPollsHub?.classList.remove("hasBadge");
+      if (pollsHubBadge) pollsHubBadge.textContent = "";
     }
   }
   

--- a/js/pages/index.js
+++ b/js/pages/index.js
@@ -12,6 +12,17 @@ const btnToggle = $("#btnToggle");
 const btnForgot = $("#btnForgot");
 
 let mode = "login"; // login | register
+const params = new URLSearchParams(location.search);
+const nextTarget = params.get("next");
+const nextTask = params.get("t");
+const nextSub = params.get("s");
+
+function buildNextUrl() {
+  const url = new URL("polls-hub.html", location.href);
+  if (nextTask) url.searchParams.set("t", nextTask);
+  if (nextSub) url.searchParams.set("s", nextSub);
+  return url.toString();
+}
 
 function setErr(m = "") { err.textContent = m; }
 function setStatus(m = "") { status.textContent = m; }
@@ -39,7 +50,11 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   const u = await getUser();
   if (u) {
-    location.href = "builder.html";
+    if (nextTarget === "polls-hub") {
+      location.href = buildNextUrl();
+    } else {
+      location.href = "builder.html";
+    }
     return;
   }
   setStatus("Niezalogowany.");
@@ -73,7 +88,11 @@ document.addEventListener("DOMContentLoaded", async () => {
       } else {
         setStatus("Loguję…");
         await signIn(loginOrEmail, pwd); // <-- może być username
-        location.href = "builder.html";
+        if (nextTarget === "polls-hub") {
+          location.href = buildNextUrl();
+        } else {
+          location.href = "builder.html";
+        }
       }
     } catch (e) {
       console.error(e);

--- a/js/pages/poll-go.js
+++ b/js/pages/poll-go.js
@@ -1,0 +1,193 @@
+// js/pages/poll-go.js
+import { sb } from "../core/supabase.js";
+import { getUser } from "../core/auth.js";
+
+const qs = new URLSearchParams(location.search);
+const taskToken = qs.get("t");
+const subToken = qs.get("s");
+
+const $ = (id) => document.getElementById(id);
+
+const title = $("title");
+const message = $("message");
+const actions = $("actions");
+const hint = $("hint");
+const emailRow = $("emailRow");
+const emailInput = $("emailInput");
+const btnEmailNext = $("btnEmailNext");
+
+function setView({ head, text, hintText }) {
+  if (title) title.textContent = head;
+  if (message) message.textContent = text;
+  if (hint) hint.textContent = hintText || "";
+}
+
+function clearActions() {
+  if (actions) actions.innerHTML = "";
+}
+
+function showEmailInput(show) {
+  if (emailRow) emailRow.style.display = show ? "flex" : "none";
+}
+
+function addAction(label, kind, handler) {
+  const btn = document.createElement("button");
+  btn.className = `btn sm ${kind || ""}`.trim();
+  btn.textContent = label;
+  btn.addEventListener("click", handler);
+  actions?.appendChild(btn);
+}
+
+function redirectToLogin() {
+  const url = new URL("index.html", location.href);
+  url.searchParams.set("from", "poll-go");
+  url.searchParams.set("next", "polls-hub");
+  if (taskToken) url.searchParams.set("t", taskToken);
+  if (subToken) url.searchParams.set("s", subToken);
+  location.href = url.toString();
+}
+
+function redirectToHub() {
+  const url = new URL("polls-hub.html", location.href);
+  if (taskToken) url.searchParams.set("t", taskToken);
+  if (subToken) url.searchParams.set("s", subToken);
+  location.href = url.toString();
+}
+
+async function handleTaskResolve(emailOverride) {
+  const { data, error } = await sb().rpc("poll_task_resolve", { p_token: taskToken, p_email: emailOverride || null });
+  if (error) throw error;
+  return data;
+}
+
+async function handleTask() {
+  const user = await getUser();
+  try {
+    const data = await handleTaskResolve();
+    if (!data?.ok) {
+      setView({ head: "Link nieważny", text: "Link jest nieważny lub nieaktywny." });
+      return;
+    }
+
+    if (data.requires_auth && !user) {
+      setView({ head: "Zaloguj się", text: "Zaloguj się, aby przejść do głosowania." });
+      clearActions();
+      addAction("Zaloguj się", "gold", redirectToLogin);
+      addAction("Wróć", "", () => history.back());
+      return;
+    }
+
+    if (data.needs_email) {
+      setView({ head: "Podaj e-mail", text: "Podaj e-mail, aby odebrać zaproszenie." });
+      showEmailInput(true);
+      clearActions();
+      addAction("Odrzuć", "danger", async () => declineTask());
+      return;
+    }
+
+    showEmailInput(false);
+    setView({ head: "Zadanie do głosowania", text: "Możesz przejść do głosowania lub odrzucić zadanie." });
+    clearActions();
+    addAction("Przejdź do głosowania", "gold", () => openVote(data.poll_type));
+    addAction("Odrzuć", "danger", async () => declineTask());
+  } catch (e) {
+    console.error(e);
+    setView({ head: "Błąd", text: "Nie udało się otworzyć zaproszenia." });
+  }
+}
+
+function openVote(type) {
+  const page = type === "poll_points" ? "poll-points.html" : "poll-text.html";
+  location.href = `${page}?t=${encodeURIComponent(taskToken)}`;
+}
+
+async function declineTask() {
+  try {
+    await sb().rpc("poll_task_decline", { p_token: taskToken });
+    setView({ head: "Odrzucono", text: "Zadanie zostało odrzucone." });
+    clearActions();
+    addAction("Wróć", "", () => history.back());
+  } catch (e) {
+    console.error(e);
+    setView({ head: "Błąd", text: "Nie udało się odrzucić zadania." });
+  }
+}
+
+async function handleSub() {
+  const user = await getUser();
+  if (user) {
+    setView({ head: "Zaproszenie do subskrypcji", text: "Masz zaproszenie do subskrypcji. Przejdź do centrum sondaży, aby je obsłużyć." });
+    clearActions();
+    addAction("Przejdź do centrum", "gold", redirectToHub);
+    return;
+  }
+
+  setView({ head: "Zaproszenie do subskrypcji", text: "Podaj e-mail, aby zaakceptować zaproszenie." });
+  showEmailInput(true);
+  clearActions();
+  addAction("Subskrybuj", "gold", async () => acceptSubEmail());
+  addAction("Odrzuć", "danger", async () => declineSub());
+  if (hint) hint.textContent = "Możesz też zalogować się na konto, aby powiązać zaproszenie.";
+}
+
+async function acceptSubEmail() {
+  const email = emailInput?.value.trim();
+  if (!email) {
+    setView({ head: "Brak e-maila", text: "Podaj poprawny adres e-mail." });
+    return;
+  }
+  try {
+    const { data, error } = await sb().rpc("poll_sub_accept_email", { p_token: subToken, p_email: email });
+    if (error) throw error;
+    if (!data?.ok) throw new Error(data?.error || "Nie udało się zaakceptować.");
+    setView({ head: "Subskrypcja aktywna", text: "Zaproszenie zostało zaakceptowane." });
+    clearActions();
+    addAction("Wróć", "", () => history.back());
+  } catch (e) {
+    console.error(e);
+    setView({ head: "Błąd", text: "Nie udało się zaakceptować zaproszenia." });
+  }
+}
+
+async function declineSub() {
+  try {
+    const { data, error } = await sb().rpc("poll_sub_decline", { p_token: subToken });
+    if (error) throw error;
+    if (!data?.ok) throw new Error(data?.error || "Nie udało się odrzucić.");
+    setView({ head: "Odrzucono", text: "Zaproszenie zostało odrzucone." });
+    clearActions();
+    addAction("Wróć", "", () => history.back());
+  } catch (e) {
+    console.error(e);
+    setView({ head: "Błąd", text: "Nie udało się odrzucić zaproszenia." });
+  }
+}
+
+btnEmailNext?.addEventListener("click", async () => {
+  if (!taskToken) return;
+  const email = emailInput?.value.trim();
+  if (!email) {
+    setView({ head: "Brak e-maila", text: "Podaj poprawny adres e-mail." });
+    return;
+  }
+  try {
+    const data = await handleTaskResolve(email);
+    if (!data?.ok) throw new Error("invalid");
+    showEmailInput(false);
+    setView({ head: "Zadanie do głosowania", text: "Możesz przejść do głosowania lub odrzucić zadanie." });
+    clearActions();
+    addAction("Przejdź do głosowania", "gold", () => openVote(data.poll_type));
+    addAction("Odrzuć", "danger", async () => declineTask());
+  } catch (e) {
+    console.error(e);
+    setView({ head: "Błąd", text: "Nie udało się potwierdzić e-maila." });
+  }
+});
+
+if (taskToken) {
+  handleTask();
+} else if (subToken) {
+  handleSub();
+} else {
+  setView({ head: "Brak linku", text: "Brakuje tokenu zaproszenia." });
+}

--- a/js/pages/poll-points.js
+++ b/js/pages/poll-points.js
@@ -3,8 +3,8 @@ import { sb } from "../core/supabase.js";
 import { getUser } from "../core/auth.js";
 
 const qs = new URLSearchParams(location.search);
-const gameId = qs.get("id");
-const key = qs.get("key");
+let gameId = qs.get("id");
+let key = qs.get("key");
 const taskToken = qs.get("t"); // <- opcjonalnie (tylko dla zadań z poll_go)
 
 const $ = (id) => document.getElementById(id);
@@ -29,9 +29,11 @@ function doneKey() {
   return `fam_poll_done_${gameId}_${key}`;
 }
 function hasDone() {
+  if (taskToken) return false;
   return localStorage.getItem(doneKey()) === "1";
 }
 function markDone() {
+  if (taskToken) return;
   localStorage.setItem(doneKey(), "1");
 }
 
@@ -63,7 +65,10 @@ function setClosedMsg(msg) {
   if (closed) closed.textContent = msg || "";
 }
 
+let taskVoterToken = null;
+let taskResolved = !taskToken;
 function getVoterToken() {
+  if (taskToken && taskVoterToken) return taskVoterToken;
   const k = `fam_voter_${gameId}_${key}`;
   let t = localStorage.getItem(k);
   if (!t) {
@@ -124,6 +129,43 @@ async function maybeReturnToHub(){
     if (!u) return;
     setTimeout(() => { location.href = "polls-hub.html"; }, 650);
   }catch{}
+}
+
+async function markTaskOpened() {
+  if (!taskToken) return;
+  try {
+    await sb().rpc("poll_task_opened", { p_token: taskToken });
+  } catch (e) {
+    console.warn("[poll-points] poll_task_opened failed:", e);
+  }
+}
+
+async function resolveTaskToken() {
+  if (!taskToken) return;
+  try {
+    const { data, error } = await sb().rpc("poll_task_resolve", { p_token: taskToken });
+    if (error) throw error;
+    if (!data?.ok || data?.kind !== "task") throw new Error("Link jest nieważny lub nieaktywny.");
+    if (data.requires_auth) {
+      setSub("Zaloguj się, aby przejść do głosowania.");
+      showClosed(true);
+      return;
+    }
+    if (data.needs_email) {
+      setSub("Podaj e-mail w linku z zaproszenia.");
+      showClosed(true);
+      return;
+    }
+    gameId = data.game_id;
+    key = data.key;
+    taskVoterToken = data.voter_token;
+    taskResolved = true;
+    await markTaskOpened();
+  } catch (e) {
+    console.error("[poll-points] task resolve error:", e);
+    setSub("Nie można otworzyć zadania.");
+    showClosed(true);
+  }
 }
 
 function setupBeforeUnloadWarn() {
@@ -216,6 +258,10 @@ function render() {
 
 document.addEventListener("DOMContentLoaded", async () => {
   try {
+    if (taskToken) {
+      await resolveTaskToken();
+    }
+    if (!taskResolved) return;
     if (!gameId || !key) {
       setSub("Brak parametru id lub key.");
       showClosed(true);

--- a/js/pages/polls-hub.js
+++ b/js/pages/polls-hub.js
@@ -1,0 +1,950 @@
+// js/pages/polls-hub.js
+import { sb } from "../core/supabase.js";
+import { requireAuth, signOut } from "../core/auth.js";
+import { validatePollReadyToOpen } from "../core/game-validate.js";
+import { confirmModal } from "../core/modal.js";
+
+const qs = new URLSearchParams(location.search);
+const focusTaskToken = qs.get("t");
+const focusSubToken = qs.get("s");
+
+const $ = (id) => document.getElementById(id);
+
+const who = $("who");
+const btnLogout = $("btnLogout");
+const btnBackToBuilder = $("btnBackToBuilder");
+
+const tabPolls = $("tabPolls");
+const tabSubs = $("tabSubs");
+const panelPolls = $("panelPolls");
+const panelSubs = $("panelSubs");
+
+const badgeTasks = $("badgeTasks");
+const badgeSubs = $("badgeSubs");
+
+const btnShare = $("btnShare");
+const btnDetails = $("btnDetails");
+const btnShareMobile = $("btnShareMobile");
+const btnDetailsMobile = $("btnDetailsMobile");
+
+const listPollsDesktop = $("pollsListDesktop");
+const listPollsMobile = $("pollsListMobile");
+const listTasksDesktop = $("tasksListDesktop");
+const listTasksMobile = $("tasksListMobile");
+const listSubscribersDesktop = $("subscribersListDesktop");
+const listSubscribersMobile = $("subscribersListMobile");
+const listSubscriptionsDesktop = $("subscriptionsListDesktop");
+const listSubscriptionsMobile = $("subscriptionsListMobile");
+
+const sortPollsDesktop = $("sortPollsDesktop");
+const sortPollsMobile = $("sortPollsMobile");
+const sortTasksDesktop = $("sortTasksDesktop");
+const sortTasksMobile = $("sortTasksMobile");
+const sortSubscribersDesktop = $("sortSubscribersDesktop");
+const sortSubscribersMobile = $("sortSubscribersMobile");
+const sortSubscriptionsDesktop = $("sortSubscriptionsDesktop");
+const sortSubscriptionsMobile = $("sortSubscriptionsMobile");
+
+const inviteInputDesktop = $("inviteInputDesktop");
+const inviteInputMobile = $("inviteInputMobile");
+const btnInviteDesktop = $("btnInviteDesktop");
+const btnInviteMobile = $("btnInviteMobile");
+
+const shareOverlay = $("shareOverlay");
+const shareList = $("shareList");
+const shareMsg = $("shareMsg");
+const btnShareSave = $("btnShareSave");
+const btnShareClose = $("btnShareClose");
+
+const detailsOverlay = $("detailsOverlay");
+const detailsVoted = $("detailsVoted");
+const detailsPending = $("detailsPending");
+const detailsAnon = $("detailsAnon");
+const btnDetailsClose = $("btnDetailsClose");
+const detailsTitle = $("detailsTitle");
+
+let currentUser = null;
+let selectedPollId = null;
+let selectedPoll = null;
+let polls = [];
+let tasks = [];
+let subscribers = [];
+let subscriptions = [];
+let pollClosedAt = new Map();
+let pollReadyMap = new Map();
+let sharePollId = null;
+
+const sortState = {
+  polls: "newest",
+  tasks: "newest",
+  subscribers: "newest",
+  subscriptions: "newest",
+};
+
+const archiveState = {
+  polls: false,
+  tasks: false,
+  subscribers: false,
+  subscriptions: false,
+};
+
+const sortOptions = {
+  polls: [
+    { value: "newest", label: "Najnowsze" },
+    { value: "oldest", label: "Najstarsze" },
+    { value: "name-asc", label: "Nazwa A–Z" },
+    { value: "name-desc", label: "Nazwa Z–A" },
+    { value: "type", label: "Typ" },
+    { value: "state", label: "Stan" },
+    { value: "tasks-active", label: "Najwięcej aktywnych zadań" },
+    { value: "tasks-done", label: "Najwięcej oddanych zadań" },
+  ],
+  tasks: [
+    { value: "newest", label: "Najnowsze" },
+    { value: "oldest", label: "Najstarsze" },
+    { value: "name-asc", label: "Nazwa A–Z" },
+    { value: "name-desc", label: "Nazwa Z–A" },
+    { value: "type", label: "Typ" },
+    { value: "available", label: "Tylko dostępne" },
+    { value: "done", label: "Tylko wykonane" },
+  ],
+  subscribers: [
+    { value: "newest", label: "Najnowsze" },
+    { value: "oldest", label: "Najstarsze" },
+    { value: "name-asc", label: "Nazwa/Email A–Z" },
+    { value: "name-desc", label: "Nazwa/Email Z–A" },
+    { value: "status", label: "Status" },
+  ],
+  subscriptions: [
+    { value: "newest", label: "Najnowsze" },
+    { value: "oldest", label: "Najstarsze" },
+    { value: "name-asc", label: "Nazwa A–Z" },
+    { value: "name-desc", label: "Nazwa Z–A" },
+    { value: "status", label: "Status" },
+  ],
+};
+
+function renderSelect(el, kind) {
+  if (!el) return;
+  el.innerHTML = "";
+  for (const opt of sortOptions[kind]) {
+    const o = document.createElement("option");
+    o.value = opt.value;
+    o.textContent = opt.label;
+    el.appendChild(o);
+  }
+  el.value = sortState[kind];
+}
+
+function setActiveTab(tab) {
+  const isPolls = tab === "polls";
+  tabPolls?.classList.toggle("active", isPolls);
+  tabSubs?.classList.toggle("active", !isPolls);
+  panelPolls?.classList.toggle("active", isPolls);
+  panelSubs?.classList.toggle("active", !isPolls);
+}
+
+function updateBadges() {
+  const tasksPending = tasks.filter((t) => t.status === "pending").length;
+  const subsPending = subscribers.filter((s) => s.status === "pending").length;
+  if (badgeTasks) badgeTasks.textContent = String(tasksPending || 0);
+  if (badgeSubs) badgeSubs.textContent = String(subsPending || 0);
+}
+
+function pollTypeLabel(t) {
+  return t === "poll_points" ? "Punktacja odpowiedzi" : "Typowy sondaż";
+}
+
+function getPollStateOrder(poll) {
+  if (poll.poll_state === "draft") return 0;
+  if (poll.poll_state === "open") return 1;
+  return 2;
+}
+
+function parseDate(d) {
+  return d ? new Date(d).getTime() : 0;
+}
+
+function isPollArchived(poll) {
+  if (poll.poll_state !== "closed") return false;
+  const closedAt = pollClosedAt.get(poll.game_id) || poll.created_at;
+  return Date.now() - parseDate(closedAt) > 5 * 24 * 60 * 60 * 1000;
+}
+
+function sortPollsList(list) {
+  const sorted = [...list];
+  switch (sortState.polls) {
+    case "oldest":
+      sorted.sort((a, b) => parseDate(a.created_at) - parseDate(b.created_at));
+      break;
+    case "name-asc":
+      sorted.sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+      break;
+    case "name-desc":
+      sorted.sort((a, b) => (b.name || "").localeCompare(a.name || ""));
+      break;
+    case "type":
+      sorted.sort((a, b) => pollTypeLabel(a.poll_type).localeCompare(pollTypeLabel(b.poll_type)));
+      break;
+    case "state":
+      sorted.sort((a, b) => getPollStateOrder(a) - getPollStateOrder(b));
+      break;
+    case "tasks-active":
+      sorted.sort((a, b) => (b.tasks_active || 0) - (a.tasks_active || 0));
+      break;
+    case "tasks-done":
+      sorted.sort((a, b) => (b.tasks_done || 0) - (a.tasks_done || 0));
+      break;
+    default:
+      sorted.sort((a, b) => parseDate(b.created_at) - parseDate(a.created_at));
+  }
+  return sorted;
+}
+
+function sortTasksList(list) {
+  let filtered = [...list];
+  if (sortState.tasks === "available") {
+    filtered = filtered.filter((t) => t.status === "pending");
+  }
+  if (sortState.tasks === "done") {
+    filtered = filtered.filter((t) => t.status === "done");
+  }
+  switch (sortState.tasks) {
+    case "oldest":
+      filtered.sort((a, b) => parseDate(a.created_at) - parseDate(b.created_at));
+      break;
+    case "name-asc":
+      filtered.sort((a, b) => (a.game_name || "").localeCompare(b.game_name || ""));
+      break;
+    case "name-desc":
+      filtered.sort((a, b) => (b.game_name || "").localeCompare(a.game_name || ""));
+      break;
+    case "type":
+      filtered.sort((a, b) => pollTypeLabel(a.poll_type).localeCompare(pollTypeLabel(b.poll_type)));
+      break;
+    default:
+      filtered.sort((a, b) => parseDate(b.created_at) - parseDate(a.created_at));
+  }
+  return filtered;
+}
+
+function sortSubscribersList(list) {
+  const sorted = [...list];
+  switch (sortState.subscribers) {
+    case "oldest":
+      sorted.sort((a, b) => parseDate(a.created_at) - parseDate(b.created_at));
+      break;
+    case "name-asc":
+      sorted.sort((a, b) => (a.subscriber_label || "").localeCompare(b.subscriber_label || ""));
+      break;
+    case "name-desc":
+      sorted.sort((a, b) => (b.subscriber_label || "").localeCompare(a.subscriber_label || ""));
+      break;
+    case "status":
+      sorted.sort((a, b) => subscriberStatusOrder(a.status) - subscriberStatusOrder(b.status));
+      break;
+    default:
+      sorted.sort((a, b) => parseDate(b.created_at) - parseDate(a.created_at));
+  }
+  return sorted;
+}
+
+function sortSubscriptionsList(list) {
+  const sorted = [...list];
+  switch (sortState.subscriptions) {
+    case "oldest":
+      sorted.sort((a, b) => parseDate(a.created_at) - parseDate(b.created_at));
+      break;
+    case "name-asc":
+      sorted.sort((a, b) => (a.owner_label || "").localeCompare(b.owner_label || ""));
+      break;
+    case "name-desc":
+      sorted.sort((a, b) => (b.owner_label || "").localeCompare(a.owner_label || ""));
+      break;
+    case "status":
+      sorted.sort((a, b) => subscriptionStatusOrder(a.status) - subscriptionStatusOrder(b.status));
+      break;
+    default:
+      sorted.sort((a, b) => parseDate(b.created_at) - parseDate(a.created_at));
+  }
+  return sorted;
+}
+
+function subscriberStatusOrder(status) {
+  if (status === "active") return 0;
+  if (status === "pending") return 1;
+  return 2;
+}
+
+function subscriptionStatusOrder(status) {
+  if (status === "active") return 0;
+  return 1;
+}
+
+function pollTileClass(poll) {
+  if (poll.poll_state === "closed") return "poll-closed";
+  if (poll.poll_state === "open") {
+    const hasVotes = (poll.anon_votes || 0) > 0 || (poll.tasks_active || 0) > 0;
+    const isGood = (poll.anon_votes || 0) >= 10 || ((poll.tasks_active || 0) === 0 && (poll.tasks_done || 0) > 0);
+    if (isGood) return "poll-open-good";
+    return hasVotes ? "poll-open-active" : "poll-open-empty";
+  }
+  const ready = pollReadyMap.get(poll.game_id) === true;
+  return ready ? "poll-draft-ready" : "poll-draft";
+}
+
+function renderEmpty(listEl, text) {
+  if (!listEl) return;
+  listEl.innerHTML = `<div class="hub-empty">${text}</div>`;
+}
+
+function renderPolls() {
+  const visible = polls.filter((p) => (archiveState.polls ? isPollArchived(p) : !isPollArchived(p)));
+  const sorted = sortPollsList(visible);
+  const render = (listEl) => {
+    if (!listEl) return;
+    listEl.innerHTML = "";
+    if (!sorted.length) {
+      renderEmpty(listEl, "Brak sondaży do pokazania.");
+      return;
+    }
+    for (const poll of sorted) {
+      const item = document.createElement("div");
+      item.className = `hub-item ${pollTileClass(poll)} ${poll.game_id === selectedPollId ? "selected" : ""}`;
+      item.dataset.id = poll.game_id;
+      item.innerHTML = `
+        <div>
+          <div class="hub-item-title">${pollTypeLabel(poll.poll_type)} — ${poll.name || "—"}</div>
+          <div class="hub-item-sub">${poll.poll_state === "open" ? "Otwarty" : poll.poll_state === "closed" ? "Zamknięty" : "Szkic"}</div>
+        </div>
+      `;
+      item.addEventListener("click", () => selectPoll(poll));
+      item.addEventListener("dblclick", () => openPoll(poll));
+      listEl.appendChild(item);
+    }
+  };
+  render(listPollsDesktop);
+  render(listPollsMobile);
+}
+
+function renderTasks() {
+  const visible = tasks.filter((t) => {
+    if (t.status === "declined" || t.status === "cancelled") return false;
+    if (archiveState.tasks) return t.is_archived && t.status === "done";
+    return !t.is_archived && (t.status === "pending" || t.status === "done");
+  });
+  const sorted = sortTasksList(visible);
+  const render = (listEl) => {
+    if (!listEl) return;
+    listEl.innerHTML = "";
+    if (!sorted.length) {
+      renderEmpty(listEl, "Brak zadań do pokazania.");
+      return;
+    }
+    for (const task of sorted) {
+      const item = document.createElement("div");
+      const statusClass = task.status === "done" ? "task-done" : "task-pending";
+      item.className = `hub-item ${statusClass}`;
+      item.innerHTML = `
+        <div>
+          <div class="hub-item-title">${pollTypeLabel(task.poll_type)} — ${task.game_name || "—"}</div>
+          <div class="hub-item-sub">${task.status === "done" ? "Wykonane" : "Dostępne"}</div>
+        </div>
+        <div class="hub-item-actions"></div>
+      `;
+      const actions = item.querySelector(".hub-item-actions");
+      if (task.status === "pending") {
+        const btn = document.createElement("button");
+        btn.className = "btn xs danger";
+        btn.textContent = "X";
+        btn.title = "Odrzuć";
+        btn.addEventListener("click", async (e) => {
+          e.stopPropagation();
+          await declineTask(task);
+        });
+        actions?.appendChild(btn);
+      }
+      item.addEventListener("dblclick", () => openTask(task));
+      listEl.appendChild(item);
+    }
+  };
+  render(listTasksDesktop);
+  render(listTasksMobile);
+}
+
+function renderSubscribers() {
+  const visible = subscribers.filter((s) => {
+    if (archiveState.subscribers) return s.is_expired || s.status === "declined" || s.status === "cancelled";
+    return s.status === "pending" || s.status === "active";
+  });
+  const sorted = sortSubscribersList(visible);
+  const render = (listEl) => {
+    if (!listEl) return;
+    listEl.innerHTML = "";
+    if (!sorted.length) {
+      renderEmpty(listEl, "Brak subskrybentów.");
+      return;
+    }
+    for (const sub of sorted) {
+      const statusClass = sub.status === "active" ? "sub-active" : sub.status === "pending" ? "sub-pending" : "sub-declined";
+      const item = document.createElement("div");
+      item.className = `hub-item ${statusClass}`;
+      item.innerHTML = `
+        <div>
+          <div class="hub-item-title">${sub.subscriber_label || "—"}</div>
+          <div class="hub-item-sub">${statusLabel(sub.status)}</div>
+        </div>
+        <div class="hub-item-actions"></div>
+      `;
+      const actions = item.querySelector(".hub-item-actions");
+      const btnRemove = document.createElement("button");
+      btnRemove.className = "btn xs danger";
+      btnRemove.textContent = "X";
+      btnRemove.title = "Usuń";
+      btnRemove.addEventListener("click", async (e) => {
+        e.stopPropagation();
+        await removeSubscriber(sub);
+      });
+      actions?.appendChild(btnRemove);
+
+      if (sub.status === "pending") {
+        const btnResend = document.createElement("button");
+        btnResend.className = "btn xs";
+        btnResend.textContent = "↻";
+        btnResend.title = "Ponów zaproszenie";
+        btnResend.addEventListener("click", async (e) => {
+          e.stopPropagation();
+          await resendSubscriber(sub);
+        });
+        actions?.appendChild(btnResend);
+      }
+      listEl.appendChild(item);
+    }
+  };
+  render(listSubscribersDesktop);
+  render(listSubscribersMobile);
+}
+
+function renderSubscriptions() {
+  const visible = subscriptions.filter((s) => {
+    if (archiveState.subscriptions) return s.is_expired;
+    return true;
+  });
+  const sorted = sortSubscriptionsList(visible);
+  const render = (listEl) => {
+    if (!listEl) return;
+    listEl.innerHTML = "";
+    if (!sorted.length) {
+      renderEmpty(listEl, "Brak subskrypcji.");
+      return;
+    }
+    for (const sub of sorted) {
+      const statusClass = sub.status === "active" ? "sub-active" : "sub-pending";
+      const item = document.createElement("div");
+      item.className = `hub-item ${statusClass}`;
+      item.innerHTML = `
+        <div>
+          <div class="hub-item-title">${sub.owner_label || "—"}</div>
+          <div class="hub-item-sub">${statusLabel(sub.status)}</div>
+        </div>
+        <div class="hub-item-actions"></div>
+      `;
+      const actions = item.querySelector(".hub-item-actions");
+      const btnRemove = document.createElement("button");
+      btnRemove.className = "btn xs danger";
+      btnRemove.textContent = "X";
+      btnRemove.title = sub.status === "pending" ? "Odrzuć" : "Anuluj";
+      btnRemove.addEventListener("click", async (e) => {
+        e.stopPropagation();
+        await rejectSubscription(sub);
+      });
+      actions?.appendChild(btnRemove);
+
+      if (sub.status === "pending") {
+        const btnAccept = document.createElement("button");
+        btnAccept.className = "btn xs gold";
+        btnAccept.textContent = "✓";
+        btnAccept.title = "Akceptuj";
+        btnAccept.addEventListener("click", async (e) => {
+          e.stopPropagation();
+          await acceptSubscription(sub);
+        });
+        actions?.appendChild(btnAccept);
+      }
+
+      listEl.appendChild(item);
+    }
+  };
+  render(listSubscriptionsDesktop);
+  render(listSubscriptionsMobile);
+}
+
+function statusLabel(status) {
+  if (status === "active") return "Aktywny";
+  if (status === "pending") return "Oczekujące";
+  if (status === "declined") return "Odrzucone";
+  if (status === "cancelled") return "Anulowane";
+  return status;
+}
+
+function selectPoll(poll) {
+  selectedPollId = poll.game_id;
+  selectedPoll = poll;
+  renderPolls();
+  updatePollActions();
+}
+
+function updatePollActions() {
+  const isOpen = selectedPoll?.poll_state === "open";
+  const canShare = !!selectedPollId && isOpen;
+  const canDetails = !!selectedPollId && selectedPoll?.poll_state !== "draft";
+  btnShare && (btnShare.disabled = !canShare);
+  btnShareMobile && (btnShareMobile.disabled = !canShare);
+  btnDetails && (btnDetails.disabled = !canDetails);
+  btnDetailsMobile && (btnDetailsMobile.disabled = !canDetails);
+}
+
+async function openPoll(poll) {
+  if (poll.poll_state === "draft" && !pollReadyMap.get(poll.game_id)) {
+    alert("Dokończ grę w Moich grach");
+    return;
+  }
+  location.href = `polls.html?id=${encodeURIComponent(poll.game_id)}`;
+}
+
+function extractToken(goUrl, key) {
+  if (!goUrl) return null;
+  try {
+    const url = new URL(goUrl, location.href);
+    return url.searchParams.get(key);
+  } catch {
+    const params = new URLSearchParams(goUrl.split("?")[1] || "");
+    return params.get(key);
+  }
+}
+
+function openTask(task) {
+  if (task.status !== "pending") return;
+  const token = extractToken(task.go_url, "t");
+  if (!token) return;
+  const page = task.poll_type === "poll_points" ? "poll-points.html" : "poll-text.html";
+  location.href = `${page}?t=${encodeURIComponent(token)}`;
+}
+
+async function declineTask(task) {
+  try {
+    await sb().rpc("polls_hub_task_decline", { p_task_id: task.task_id });
+    await refreshData();
+  } catch (e) {
+    console.error(e);
+    alert("Nie udało się odrzucić zadania.");
+  }
+}
+
+async function inviteSubscriber(recipient) {
+  if (!recipient) return;
+  try {
+    const { data, error } = await sb().rpc("polls_hub_subscription_invite", { p_recipient: recipient });
+    if (error) throw error;
+    if (data?.ok === false) throw new Error(data?.error || "Nie udało się zaprosić.");
+    await refreshData();
+  } catch (e) {
+    console.error(e);
+    alert(e?.message || "Nie udało się zaprosić.");
+  }
+}
+
+async function resendSubscriber(sub) {
+  try {
+    await sb().rpc("polls_hub_subscriber_resend", { p_id: sub.sub_id });
+    await refreshData();
+  } catch (e) {
+    console.error(e);
+    alert("Nie udało się ponowić zaproszenia.");
+  }
+}
+
+async function removeSubscriber(sub) {
+  const ok = await confirmModal({
+    title: "Usuń subskrybenta",
+    text: "Czy na pewno chcesz usunąć tego subskrybenta?",
+    okText: "Usuń",
+    cancelText: "Anuluj",
+  });
+  if (!ok) return;
+  try {
+    await sb().rpc("polls_hub_subscriber_remove", { p_id: sub.sub_id });
+    await refreshData();
+  } catch (e) {
+    console.error(e);
+    alert("Nie udało się usunąć subskrybenta.");
+  }
+}
+
+async function acceptSubscription(sub) {
+  try {
+    await sb().rpc("polls_hub_subscription_accept", { p_id: sub.sub_id });
+    await refreshData();
+  } catch (e) {
+    console.error(e);
+    alert("Nie udało się zaakceptować zaproszenia.");
+  }
+}
+
+async function rejectSubscription(sub) {
+  try {
+    const rpc = sub.status === "pending" ? "polls_hub_subscription_reject" : "polls_hub_subscription_cancel";
+    await sb().rpc(rpc, { p_id: sub.sub_id });
+    await refreshData();
+  } catch (e) {
+    console.error(e);
+    alert("Nie udało się zaktualizować subskrypcji.");
+  }
+}
+
+async function openShareModal() {
+  if (!selectedPollId) return;
+  sharePollId = selectedPollId;
+  shareMsg.textContent = "";
+  shareList.innerHTML = "";
+  try {
+    const activeSubs = subscribers.filter((s) => s.status === "active");
+    const { data: taskRows, error } = await sb()
+      .from("poll_tasks")
+      .select("id,recipient_user_id,recipient_email,status")
+      .eq("game_id", sharePollId)
+      .eq("owner_id", currentUser.id);
+    if (error) throw error;
+
+    const statusBySub = new Map();
+    for (const task of taskRows || []) {
+      const key = task.recipient_user_id || (task.recipient_email || "").toLowerCase();
+      statusBySub.set(key, task.status);
+    }
+
+    for (const sub of activeSubs) {
+      const key = sub.subscriber_user_id || (sub.subscriber_email || "").toLowerCase();
+      const status = statusBySub.get(key);
+      const row = document.createElement("label");
+      row.className = "hub-share-item";
+      const isActive = status === "pending" || status === "opened";
+      row.innerHTML = `
+        <input type="checkbox" ${isActive ? "checked" : ""} data-sub-id="${sub.sub_id}">
+        <div>
+          <div class="hub-item-title">${sub.subscriber_label || "—"}</div>
+          <div class="hub-share-status">${shareStatusLabel(status)}</div>
+        </div>
+        <div class="hub-share-status">${status === "done" ? "Wykonane" : status ? "Dostępne" : "Brak"}</div>
+      `;
+      shareList.appendChild(row);
+    }
+
+    if (!activeSubs.length) {
+      shareList.innerHTML = "<div class=\"hub-empty\">Brak aktywnych subskrybentów.</div>";
+    }
+    shareOverlay.style.display = "grid";
+  } catch (e) {
+    console.error(e);
+    alert("Nie udało się pobrać subskrybentów.");
+  }
+}
+
+function shareStatusLabel(status) {
+  if (status === "done") return "Wykonane";
+  if (status === "pending" || status === "opened") return "Dostępne";
+  return "Brak";
+}
+
+async function saveShareModal() {
+  const selected = [...shareList.querySelectorAll("input[type=checkbox]")]
+    .filter((x) => x.checked)
+    .map((x) => x.dataset.subId);
+  try {
+    const { data, error } = await sb().rpc("polls_hub_share_poll", {
+      p_game_id: sharePollId,
+      p_sub_ids: selected,
+    });
+    if (error) throw error;
+    if (data?.ok === false) throw new Error(data?.error || "Nie udało się udostępnić.");
+    shareMsg.textContent = "Zapisano udostępnienie.";
+    await refreshData();
+    setTimeout(closeShareModal, 500);
+  } catch (e) {
+    console.error(e);
+    shareMsg.textContent = "Nie udało się zapisać udostępnienia.";
+  }
+}
+
+function closeShareModal() {
+  shareOverlay.style.display = "none";
+  sharePollId = null;
+}
+
+async function openDetailsModal() {
+  if (!selectedPollId) return;
+  detailsVoted.innerHTML = "";
+  detailsPending.innerHTML = "";
+  detailsAnon.textContent = String(selectedPoll?.anon_votes || 0);
+  detailsTitle.textContent = `Szczegóły głosowania — ${selectedPoll?.name || ""}`;
+  try {
+    const { data: taskRows, error } = await sb()
+      .from("poll_tasks")
+      .select("id,recipient_user_id,recipient_email,status")
+      .eq("game_id", selectedPollId)
+      .eq("owner_id", currentUser.id);
+    if (error) throw error;
+
+    const ids = [...new Set(taskRows.map((t) => t.recipient_user_id).filter(Boolean))];
+    const profiles = new Map();
+    if (ids.length) {
+      const { data: profileRows } = await sb().from("profiles").select("id,username,email").in("id", ids);
+      for (const p of profileRows || []) {
+        profiles.set(p.id, p.username || p.email || "—");
+      }
+    }
+
+    for (const task of taskRows || []) {
+      const label = task.recipient_user_id
+        ? profiles.get(task.recipient_user_id) || task.recipient_user_id
+        : task.recipient_email || "—";
+      const item = document.createElement("div");
+      item.className = "hub-details-item";
+      item.innerHTML = `
+        <div>${label}</div>
+        <div class="hub-item-actions"></div>
+      `;
+      const actions = item.querySelector(".hub-item-actions");
+      if (task.status === "done") {
+        const btn = document.createElement("button");
+        btn.className = "btn xs danger";
+        btn.textContent = "Usuń";
+        btn.addEventListener("click", async () => {
+          const ok = await confirmModal({
+            title: "Usuń głos",
+            text: "Czy na pewno chcesz usunąć głos tej osoby?",
+            okText: "Usuń",
+            cancelText: "Anuluj",
+          });
+          if (!ok) return;
+          await deleteVote(task.id);
+        });
+        actions?.appendChild(btn);
+        detailsVoted.appendChild(item);
+      } else {
+        detailsPending.appendChild(item);
+      }
+    }
+
+    if (!taskRows?.length) {
+      detailsVoted.innerHTML = "<div class=\"hub-empty\">Brak zadań.</div>";
+      detailsPending.innerHTML = "<div class=\"hub-empty\">Brak zadań.</div>";
+    }
+
+    detailsOverlay.style.display = "grid";
+  } catch (e) {
+    console.error(e);
+    alert("Nie udało się pobrać szczegółów.");
+  }
+}
+
+async function deleteVote(taskId) {
+  try {
+    await sb().rpc("poll_admin_delete_vote", { p_game_id: selectedPollId, p_voter_token: `task:${taskId}` });
+    await openDetailsModal();
+  } catch (e) {
+    console.error(e);
+    alert("Nie udało się usunąć głosu.");
+  }
+}
+
+function closeDetailsModal() {
+  detailsOverlay.style.display = "none";
+}
+
+function syncToggles() {
+  document.querySelectorAll(".hub-toggle").forEach((wrap) => {
+    const kind = wrap.dataset.kind;
+    const isArchive = archiveState[kind];
+    wrap.querySelectorAll("button").forEach((btn) => {
+      const mode = btn.dataset.toggle;
+      btn.classList.toggle("active", (mode === "archive") === isArchive);
+    });
+  });
+}
+
+function registerToggleHandlers() {
+  document.querySelectorAll(".hub-toggle button").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const kind = btn.closest(".hub-toggle")?.dataset.kind;
+      if (!kind) return;
+      archiveState[kind] = btn.dataset.toggle === "archive";
+      syncToggles();
+      renderAll();
+    });
+  });
+}
+
+function renderAll() {
+  renderPolls();
+  renderTasks();
+  renderSubscribers();
+  renderSubscriptions();
+}
+
+async function refreshData() {
+  try {
+    const [pollsRes, tasksRes, subsRes, mySubsRes] = await Promise.all([
+      sb().rpc("polls_hub_list_polls"),
+      sb().rpc("polls_hub_list_tasks"),
+      sb().rpc("polls_hub_list_my_subscribers"),
+      sb().rpc("polls_hub_list_my_subscriptions"),
+    ]);
+    polls = pollsRes.data || [];
+    tasks = tasksRes.data || [];
+    subscribers = subsRes.data || [];
+    subscriptions = mySubsRes.data || [];
+
+    if (selectedPollId && !polls.some((p) => p.game_id === selectedPollId)) {
+      selectedPollId = null;
+      selectedPoll = null;
+    }
+
+    const pollIds = polls.map((p) => p.game_id).filter(Boolean);
+    pollClosedAt = new Map();
+    if (pollIds.length) {
+      const { data: dates } = await sb().from("games").select("id,poll_closed_at").in("id", pollIds);
+      for (const row of dates || []) {
+        pollClosedAt.set(row.id, row.poll_closed_at);
+      }
+    }
+
+    pollReadyMap = new Map();
+    await Promise.all(
+      polls
+        .filter((p) => p.poll_state === "draft")
+        .map(async (p) => {
+          try {
+            const ready = await validatePollReadyToOpen(p.game_id);
+            pollReadyMap.set(p.game_id, !!ready?.ok);
+          } catch {
+            pollReadyMap.set(p.game_id, false);
+          }
+        })
+    );
+
+    updateBadges();
+    renderAll();
+    updatePollActions();
+    maybeFocusFromToken();
+  } catch (e) {
+    console.error(e);
+    alert("Nie udało się pobrać danych centrum sondaży.");
+  }
+}
+
+function maybeFocusFromToken() {
+  if (focusTaskToken) {
+    const match = tasks.find((t) => extractToken(t.go_url, "t") === focusTaskToken);
+    if (match) {
+      const page = match.poll_type === "poll_points" ? "poll-points.html" : "poll-text.html";
+      const promptVote = confirm("Masz zadanie do wykonania. Chcesz przejść do głosowania?");
+      if (promptVote) {
+        location.href = `${page}?t=${encodeURIComponent(focusTaskToken)}`;
+      }
+    }
+  }
+  if (focusSubToken) {
+    const match = subscriptions.find((s) => String(s.token) === focusSubToken);
+    if (match && match.status === "pending") {
+      const promptAccept = confirm("Masz zaproszenie do subskrypcji. Chcesz je zaakceptować?");
+      if (promptAccept) {
+        acceptSubscription(match);
+      }
+    }
+  }
+}
+
+function wireSort(selectEl, kind) {
+  if (!selectEl) return;
+  selectEl.addEventListener("change", () => {
+    sortState[kind] = selectEl.value;
+    renderAll();
+  });
+}
+
+function wireInvite(inputEl) {
+  if (!inputEl) return;
+  const handler = async () => {
+    const v = inputEl.value.trim();
+    if (!v) return;
+    await inviteSubscriber(v);
+    inputEl.value = "";
+  };
+  return handler;
+}
+
+function wireOverlayClose(overlay, onClose) {
+  overlay?.addEventListener("click", (e) => {
+    if (e.target === overlay) onClose();
+  });
+}
+
+document.addEventListener("DOMContentLoaded", async () => {
+  currentUser = await requireAuth("index.html");
+  if (who) who.textContent = currentUser?.username || currentUser?.email || "—";
+
+  renderSelect(sortPollsDesktop, "polls");
+  renderSelect(sortPollsMobile, "polls");
+  renderSelect(sortTasksDesktop, "tasks");
+  renderSelect(sortTasksMobile, "tasks");
+  renderSelect(sortSubscribersDesktop, "subscribers");
+  renderSelect(sortSubscribersMobile, "subscribers");
+  renderSelect(sortSubscriptionsDesktop, "subscriptions");
+  renderSelect(sortSubscriptionsMobile, "subscriptions");
+
+  wireSort(sortPollsDesktop, "polls");
+  wireSort(sortPollsMobile, "polls");
+  wireSort(sortTasksDesktop, "tasks");
+  wireSort(sortTasksMobile, "tasks");
+  wireSort(sortSubscribersDesktop, "subscribers");
+  wireSort(sortSubscribersMobile, "subscribers");
+  wireSort(sortSubscriptionsDesktop, "subscriptions");
+  wireSort(sortSubscriptionsMobile, "subscriptions");
+
+  registerToggleHandlers();
+  syncToggles();
+
+  tabPolls?.addEventListener("click", () => setActiveTab("polls"));
+  tabSubs?.addEventListener("click", () => setActiveTab("subs"));
+  setActiveTab("polls");
+
+  btnShare?.addEventListener("click", openShareModal);
+  btnShareMobile?.addEventListener("click", openShareModal);
+  btnDetails?.addEventListener("click", openDetailsModal);
+  btnDetailsMobile?.addEventListener("click", openDetailsModal);
+
+  btnShareSave?.addEventListener("click", saveShareModal);
+  btnShareClose?.addEventListener("click", closeShareModal);
+  btnDetailsClose?.addEventListener("click", closeDetailsModal);
+
+  wireOverlayClose(shareOverlay, closeShareModal);
+  wireOverlayClose(detailsOverlay, closeDetailsModal);
+
+  const inviteDesktop = wireInvite(inviteInputDesktop);
+  const inviteMobile = wireInvite(inviteInputMobile);
+  btnInviteDesktop?.addEventListener("click", inviteDesktop);
+  btnInviteMobile?.addEventListener("click", inviteMobile);
+  inviteInputDesktop?.addEventListener("keydown", (e) => e.key === "Enter" && inviteDesktop());
+  inviteInputMobile?.addEventListener("keydown", (e) => e.key === "Enter" && inviteMobile());
+
+  btnBackToBuilder?.addEventListener("click", () => {
+    location.href = "builder.html";
+  });
+
+  btnLogout?.addEventListener("click", async () => {
+    await signOut();
+    location.href = "index.html";
+  });
+
+  await refreshData();
+});

--- a/poll_go.html
+++ b/poll_go.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Familiada — zaproszenie</title>
+
+  <link rel="icon" href="favicon.ico"/>
+  <link rel="stylesheet" href="css/base.css"/>
+  <link rel="stylesheet" href="css/poll-go.css"/>
+
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
+  <script type="module" src="js/pages/poll-go.js" defer></script>
+</head>
+
+<body class="poll-go-body">
+  <header class="topbar">
+    <div class="brand">FAMILIADA</div>
+  </header>
+
+  <main class="wrap">
+    <section class="card poll-go-card">
+      <div class="poll-go-title" id="title">Ładuję zaproszenie…</div>
+      <div class="poll-go-sub" id="message">Proszę czekać.</div>
+
+      <div class="poll-go-email" id="emailRow" style="display:none;">
+        <input class="inp" id="emailInput" placeholder="Podaj e-mail" type="email"/>
+        <button class="btn sm" id="btnEmailNext" type="button">Dalej</button>
+      </div>
+
+      <div class="poll-go-actions" id="actions"></div>
+      <div class="poll-go-hint" id="hint"></div>
+    </section>
+  </main>
+</body>
+</html>

--- a/polls-hub.html
+++ b/polls-hub.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Familiada — centrum sondaży</title>
+
+  <link rel="icon" href="favicon.ico"/>
+  <link rel="stylesheet" href="css/base.css"/>
+  <link rel="stylesheet" href="css/builder.css"/>
+  <link rel="stylesheet" href="css/polls-hub.css"/>
+
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
+  <script type="module" src="js/pages/polls-hub.js" defer></script>
+</head>
+
+<body class="polls-hub-body">
+  <header class="topbar">
+    <div class="left">
+      <button class="btn sm" id="btnBackToBuilder" type="button">← Moje gry</button>
+    </div>
+    <div class="brand">Centrum sondaży</div>
+    <div class="right">
+      <span class="who" id="who">—</span>
+      <button class="btn sm" id="btnLogout" type="button">Wyloguj</button>
+    </div>
+  </header>
+
+  <main class="wrap">
+    <section class="hub-desktop">
+      <div class="tabs-card hub-tabs" id="hubTabs">
+        <div class="tabs-strip">
+          <div class="tab-slot slot-pollText">
+            <button class="tab-label" id="tabPolls" type="button">Sondaże</button>
+            <div class="tab-wrapper">
+              <div class="tab-active">
+                Sondaże
+                <span class="hub-tab-badge" id="badgeTasks">0</span>
+              </div>
+              <div class="tab-corner tab-corner-left"></div>
+              <div class="tab-corner tab-corner-right"></div>
+            </div>
+          </div>
+
+          <div class="tab-slot slot-pollPoints">
+            <button class="tab-label" id="tabSubs" type="button">Subskrypcje</button>
+            <div class="tab-wrapper">
+              <div class="tab-active">
+                Subskrypcje
+                <span class="hub-tab-badge" id="badgeSubs">0</span>
+              </div>
+              <div class="tab-corner tab-corner-left"></div>
+              <div class="tab-corner tab-corner-right"></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card hub-card">
+          <div class="hub-tab-panel" id="panelPolls">
+            <div class="hub-grid">
+              <section class="hub-col">
+                <div class="hub-col-head">
+                  <div>
+                    <div class="hub-col-title">Moje sondaże</div>
+                    <div class="hub-col-hint">Kliknij kafelek, aby go zaznaczyć.</div>
+                  </div>
+                  <div class="hub-controls">
+                    <select class="inp sm" id="sortPollsDesktop"></select>
+                    <div class="hub-toggle" data-kind="polls">
+                      <button class="btn xs" data-toggle="current">Aktualne</button>
+                      <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                    </div>
+                    <button class="btn xs" id="btnShare" type="button" disabled>Udostępnij</button>
+                    <button class="btn xs" id="btnDetails" type="button" disabled>Szczegóły</button>
+                  </div>
+                </div>
+                <div class="hub-list" id="pollsListDesktop"></div>
+              </section>
+
+              <section class="hub-col">
+                <div class="hub-col-head">
+                  <div>
+                    <div class="hub-col-title">Zadania</div>
+                    <div class="hub-col-hint">Dwuklik otwiera głosowanie.</div>
+                  </div>
+                  <div class="hub-controls">
+                    <select class="inp sm" id="sortTasksDesktop"></select>
+                    <div class="hub-toggle" data-kind="tasks">
+                      <button class="btn xs" data-toggle="current">Aktualne</button>
+                      <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                    </div>
+                  </div>
+                </div>
+                <div class="hub-list" id="tasksListDesktop"></div>
+              </section>
+            </div>
+          </div>
+
+          <div class="hub-tab-panel" id="panelSubs">
+            <div class="hub-grid">
+              <section class="hub-col">
+                <div class="hub-col-head">
+                  <div>
+                    <div class="hub-col-title">Moi subskrybenci</div>
+                    <div class="hub-col-hint">Zaproś nowych i zarządzaj zaproszeniami.</div>
+                  </div>
+                  <div class="hub-controls">
+                    <select class="inp sm" id="sortSubscribersDesktop"></select>
+                    <div class="hub-toggle" data-kind="subscribers">
+                      <button class="btn xs" data-toggle="current">Aktualne</button>
+                      <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                    </div>
+                  </div>
+                </div>
+                <div class="hub-invite">
+                  <input class="inp" id="inviteInputDesktop" placeholder="Email lub nazwa użytkownika"/>
+                  <button class="btn xs gold" id="btnInviteDesktop" type="button">Zaproś</button>
+                </div>
+                <div class="hub-list" id="subscribersListDesktop"></div>
+              </section>
+
+              <section class="hub-col">
+                <div class="hub-col-head">
+                  <div>
+                    <div class="hub-col-title">Moje subskrypcje</div>
+                    <div class="hub-col-hint">Akceptuj zaproszenia od innych.</div>
+                  </div>
+                  <div class="hub-controls">
+                    <select class="inp sm" id="sortSubscriptionsDesktop"></select>
+                    <div class="hub-toggle" data-kind="subscriptions">
+                      <button class="btn xs" data-toggle="current">Aktualne</button>
+                      <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                    </div>
+                  </div>
+                </div>
+                <div class="hub-list" id="subscriptionsListDesktop"></div>
+              </section>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="hub-mobile">
+      <div class="card hub-card">
+        <div class="hub-col-head">
+          <div>
+            <div class="hub-col-title">Moje sondaże</div>
+            <div class="hub-col-hint">Kliknij kafelek, aby go zaznaczyć.</div>
+          </div>
+          <div class="hub-controls">
+            <select class="inp sm" id="sortPollsMobile"></select>
+            <div class="hub-toggle" data-kind="polls">
+              <button class="btn xs" data-toggle="current">Aktualne</button>
+              <button class="btn xs" data-toggle="archive">Archiwalne</button>
+            </div>
+            <button class="btn xs" id="btnShareMobile" type="button" disabled>Udostępnij</button>
+            <button class="btn xs" id="btnDetailsMobile" type="button" disabled>Szczegóły</button>
+          </div>
+        </div>
+        <div class="hub-list" id="pollsListMobile"></div>
+      </div>
+
+      <div class="card hub-card">
+        <div class="hub-col-head">
+          <div>
+            <div class="hub-col-title">Zadania</div>
+            <div class="hub-col-hint">Dwuklik otwiera głosowanie.</div>
+          </div>
+          <div class="hub-controls">
+            <select class="inp sm" id="sortTasksMobile"></select>
+            <div class="hub-toggle" data-kind="tasks">
+              <button class="btn xs" data-toggle="current">Aktualne</button>
+              <button class="btn xs" data-toggle="archive">Archiwalne</button>
+            </div>
+          </div>
+        </div>
+        <div class="hub-list" id="tasksListMobile"></div>
+      </div>
+
+      <div class="card hub-card">
+        <div class="hub-col-head">
+          <div>
+            <div class="hub-col-title">Moi subskrybenci</div>
+            <div class="hub-col-hint">Zaproś nowych i zarządzaj zaproszeniami.</div>
+          </div>
+          <div class="hub-controls">
+            <select class="inp sm" id="sortSubscribersMobile"></select>
+            <div class="hub-toggle" data-kind="subscribers">
+              <button class="btn xs" data-toggle="current">Aktualne</button>
+              <button class="btn xs" data-toggle="archive">Archiwalne</button>
+            </div>
+          </div>
+        </div>
+        <div class="hub-invite">
+          <input class="inp" id="inviteInputMobile" placeholder="Email lub nazwa użytkownika"/>
+          <button class="btn xs gold" id="btnInviteMobile" type="button">Zaproś</button>
+        </div>
+        <div class="hub-list" id="subscribersListMobile"></div>
+      </div>
+
+      <div class="card hub-card">
+        <div class="hub-col-head">
+          <div>
+            <div class="hub-col-title">Moje subskrypcje</div>
+            <div class="hub-col-hint">Akceptuj zaproszenia od innych.</div>
+          </div>
+          <div class="hub-controls">
+            <select class="inp sm" id="sortSubscriptionsMobile"></select>
+            <div class="hub-toggle" data-kind="subscriptions">
+              <button class="btn xs" data-toggle="current">Aktualne</button>
+              <button class="btn xs" data-toggle="archive">Archiwalne</button>
+            </div>
+          </div>
+        </div>
+        <div class="hub-list" id="subscriptionsListMobile"></div>
+      </div>
+    </section>
+  </main>
+
+  <div class="overlay" id="shareOverlay" style="display:none;">
+    <div class="modal">
+      <div class="mTitle" id="shareTitle">Udostępnij sondaż</div>
+      <div class="mSub">Wybierz subskrybentów, którym chcesz wysłać zadanie.</div>
+      <div class="hub-share-list" id="shareList"></div>
+      <div class="hub-modal-actions">
+        <button class="btn sm gold" id="btnShareSave" type="button">Zapisz udostępnienie</button>
+        <button class="btn sm" id="btnShareClose" type="button">Zamknij</button>
+        <div class="hub-modal-msg" id="shareMsg"></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="overlay" id="detailsOverlay" style="display:none;">
+    <div class="modal">
+      <div class="mTitle" id="detailsTitle">Szczegóły głosowania</div>
+      <div class="mSub">Usuń głos powiązany z zadaniem, jeśli to konieczne.</div>
+      <div class="hub-details">
+        <div>
+          <div class="hub-details-head">Zagłosowali</div>
+          <div class="hub-details-list" id="detailsVoted"></div>
+        </div>
+        <div>
+          <div class="hub-details-head">Nie zagłosowali / Odrzucili</div>
+          <div class="hub-details-list" id="detailsPending"></div>
+        </div>
+        <div class="hub-details-side">
+          <div class="hub-details-head">Anonimowe</div>
+          <div class="hub-anon-count" id="detailsAnon">0</div>
+        </div>
+      </div>
+      <div class="hub-modal-actions">
+        <button class="btn sm" id="btnDetailsClose" type="button">Zamknij</button>
+      </div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Implement the Polls Hub UI and Poll‑Go entry flow so task/subscription tokens from emails can be handled and owners can manage shares/tasks as specified in the frontend spec. 
- Integrate task token behavior into existing voting pages so mail‑invited voters work reliably and owner workflows (open/mark/done) are synchronized with DB RPCs.

### Description
- Added a new `polls-hub.html` page with responsive desktop/mobile layout, lists, sort/archival toggles, badges and modals for `Share` and `Details` and a new `js/pages/polls-hub.js` controller that calls Supabase RPCs (`polls_hub_list_*`, `polls_hub_share_poll`, `polls_hub_*`) and `polls_badge_get` for counts. 
- Implemented Poll‑Go landing page (`poll_go.html`, `js/pages/poll-go.js`, `css/poll-go.css`) that resolves `t=<token>` and `s=<token>` via `poll_task_resolve` / `poll_go` RPCs, supports email confirmation flows, login redirect to `index.html?next=polls-hub`, and routes users to voting pages or polls hub. 
- Updated voting pages (`js/pages/poll-text.js`, `js/pages/poll-points.js`) to support task tokens: added `poll_task_resolve`, `poll_task_opened`, `poll_task_done` calls, use task-scoped `voter_token` when provided, and avoid marking anonymous localStorage done keys for task flows. 
- Updated Builder and Index: added badge element to the Polls button in `builder.html` and `css/builder.css`, fetch badge via `polls_badge_get()` in `js/pages/builder.js`, and updated `js/pages/index.js` to preserve `t`/`s` tokens and redirect to `polls-hub.html` after login.

### Testing
- Started a local static server with `python -m http.server 8000 --bind 0.0.0.0` and ran an automated Playwright script that loaded `http://127.0.0.1:8000/poll_go.html` and captured a screenshot; the script completed and produced `artifacts/poll-go.png` successfully. 
- Performed smoke checks by loading the new pages locally (static server + browser script); these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698745b5df8c8321add26251806713ba)