### PR TITLE
Adjust poll-go invitation flows and add mobile tabs to polls hub

### DIFF
--- a/css/polls-hub.css
+++ b/css/polls-hub.css
@@ -227,8 +227,19 @@ body.polls-hub-body {
 
 .hub-mobile {
   display: none;
-  flex-direction: column;
-  gap: 14px;
+}
+
+.hub-tabs-mobile {
+  --tab-height: 44px;
+}
+
+.hub-tabs-mobile .tabs-strip {
+  gap: 8px;
+}
+
+.hub-tabs-mobile .tab-label {
+  font-size: 10px;
+  letter-spacing: .04em;
 }
 
 .hub-empty {
@@ -318,7 +329,7 @@ body.polls-hub-body {
   }
 
   .hub-mobile {
-    display: flex;
+    display: block;
   }
 
   .hub-grid {

--- a/js/pages/poll-go.js
+++ b/js/pages/poll-go.js
@@ -5,6 +5,7 @@ import { getUser } from "../core/auth.js";
 const qs = new URLSearchParams(location.search);
 const taskToken = qs.get("t");
 const subToken = qs.get("s");
+const goToken = taskToken || subToken;
 
 const $ = (id) => document.getElementById(id);
 
@@ -54,140 +55,240 @@ function redirectToHub() {
   location.href = url.toString();
 }
 
-async function handleTaskResolve(emailOverride) {
-  const { data, error } = await sb().rpc("poll_task_resolve", { p_token: taskToken, p_email: emailOverride || null });
+function normalizeEmail(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+async function resolveToken() {
+  const { data, error } = await sb().rpc("poll_go_resolve", { p_token: goToken });
   if (error) throw error;
   return data;
 }
 
-async function handleTask() {
-  const user = await getUser();
-  try {
-    const data = await handleTaskResolve();
-    if (!data?.ok) {
-      setView({ head: "Link nieważny", text: "Link jest nieważny lub nieaktywny." });
-      return;
-    }
-
-    if (data.requires_auth && !user) {
-      setView({ head: "Zaloguj się", text: "Zaloguj się, aby przejść do głosowania." });
-      clearActions();
-      addAction("Zaloguj się", "gold", redirectToLogin);
-      addAction("Wróć", "", () => history.back());
-      return;
-    }
-
-    if (data.needs_email) {
-      setView({ head: "Podaj e-mail", text: "Podaj e-mail, aby odebrać zaproszenie." });
-      showEmailInput(true);
-      clearActions();
-      addAction("Odrzuć", "danger", async () => declineTask());
-      return;
-    }
-
-    showEmailInput(false);
-    setView({ head: "Zadanie do głosowania", text: "Możesz przejść do głosowania lub odrzucić zadanie." });
-    clearActions();
-    addAction("Przejdź do głosowania", "gold", () => openVote(data.poll_type));
-    addAction("Odrzuć", "danger", async () => declineTask());
-  } catch (e) {
-    console.error(e);
-    setView({ head: "Błąd", text: "Nie udało się otworzyć zaproszenia." });
-  }
-}
-
 function openVote(type) {
   const page = type === "poll_points" ? "poll-points.html" : "poll-text.html";
-  location.href = `${page}?t=${encodeURIComponent(taskToken)}`;
+  location.href = `${page}?t=${encodeURIComponent(goToken)}`;
 }
 
 async function declineTask() {
   try {
-    await sb().rpc("poll_task_decline", { p_token: taskToken });
+    await sb().rpc("poll_task_decline", { p_token: goToken });
     setView({ head: "Odrzucono", text: "Zadanie zostało odrzucone." });
     clearActions();
-    addAction("Wróć", "", () => history.back());
   } catch (e) {
     console.error(e);
     setView({ head: "Błąd", text: "Nie udało się odrzucić zadania." });
   }
 }
 
-async function handleSub() {
-  const user = await getUser();
-  if (user) {
-    setView({ head: "Zaproszenie do subskrypcji", text: "Masz zaproszenie do subskrypcji. Przejdź do centrum sondaży, aby je obsłużyć." });
-    clearActions();
-    addAction("Przejdź do centrum", "gold", redirectToHub);
-    return;
-  }
-
-  setView({ head: "Zaproszenie do subskrypcji", text: "Podaj e-mail, aby zaakceptować zaproszenie." });
-  showEmailInput(true);
-  clearActions();
-  addAction("Subskrybuj", "gold", async () => acceptSubEmail());
-  addAction("Odrzuć", "danger", async () => declineSub());
-  if (hint) hint.textContent = "Możesz też zalogować się na konto, aby powiązać zaproszenie.";
+function buildSubHeading(data) {
+  const owner = data?.owner_label ? ` od użytkownika ${data.owner_label}` : "";
+  return `Zaproszenie do subskrypcji${owner}`;
 }
 
-async function acceptSubEmail() {
-  const email = emailInput?.value.trim();
-  if (!email) {
-    setView({ head: "Brak e-maila", text: "Podaj poprawny adres e-mail." });
-    return;
-  }
+function buildTaskHeading(data) {
+  const name = data?.game_name ? `„${data.game_name}”` : "sondażu";
+  const owner = data?.owner_label ? ` od użytkownika ${data.owner_label}` : "";
+  return `Zaproszenie do głosowania w ${name}${owner}`;
+}
+
+function showMismatch(head, expectedEmail) {
+  const emailText = expectedEmail || "adresata zaproszenia";
+  setView({
+    head,
+    text: `Zaproszenie Ciebie nie dotyczy, zaloguj się jako ${emailText} i spróbuj ponownie.`,
+  });
+  clearActions();
+  showEmailInput(false);
+}
+
+function showExpired(head) {
+  setView({ head, text: "Zaproszenie zostało wykorzystane." });
+  clearActions();
+  showEmailInput(false);
+}
+
+async function acceptSubDirect(email) {
   try {
-    const { data, error } = await sb().rpc("poll_sub_accept_email", { p_token: subToken, p_email: email });
+    const { data, error } = await sb().rpc("poll_sub_accept_email", { p_token: goToken, p_email: email });
     if (error) throw error;
     if (!data?.ok) throw new Error(data?.error || "Nie udało się zaakceptować.");
     setView({ head: "Subskrypcja aktywna", text: "Zaproszenie zostało zaakceptowane." });
     clearActions();
-    addAction("Wróć", "", () => history.back());
   } catch (e) {
     console.error(e);
     setView({ head: "Błąd", text: "Nie udało się zaakceptować zaproszenia." });
   }
 }
 
-async function declineSub() {
-  try {
-    const { data, error } = await sb().rpc("poll_sub_decline", { p_token: subToken });
-    if (error) throw error;
-    if (!data?.ok) throw new Error(data?.error || "Nie udało się odrzucić.");
-    setView({ head: "Odrzucono", text: "Zaproszenie zostało odrzucone." });
-    clearActions();
-    addAction("Wróć", "", () => history.back());
-  } catch (e) {
-    console.error(e);
-    setView({ head: "Błąd", text: "Nie udało się odrzucić zaproszenia." });
-  }
-}
-
-btnEmailNext?.addEventListener("click", async () => {
-  if (!taskToken) return;
+async function subscribeByEmail() {
   const email = emailInput?.value.trim();
   if (!email) {
     setView({ head: "Brak e-maila", text: "Podaj poprawny adres e-mail." });
     return;
   }
   try {
-    const data = await handleTaskResolve(email);
-    if (!data?.ok) throw new Error("invalid");
-    showEmailInput(false);
-    setView({ head: "Zadanie do głosowania", text: "Możesz przejść do głosowania lub odrzucić zadanie." });
+    const { data, error } = await sb().rpc("poll_go_subscribe_email", { p_token: goToken, p_email: email });
+    if (error) throw error;
+    if (!data) throw new Error("Nie udało się zasubskrybować.");
+    setView({ head: "Subskrypcja aktywna", text: "Subskrypcja została dodana." });
     clearActions();
-    addAction("Przejdź do głosowania", "gold", () => openVote(data.poll_type));
-    addAction("Odrzuć", "danger", async () => declineTask());
+    showEmailInput(false);
   } catch (e) {
     console.error(e);
-    setView({ head: "Błąd", text: "Nie udało się potwierdzić e-maila." });
+    setView({ head: "Błąd", text: "Nie udało się dodać subskrypcji." });
   }
+}
+
+async function declineSub() {
+  try {
+    const { data, error } = await sb().rpc("poll_sub_decline", { p_token: goToken });
+    if (error) throw error;
+    if (!data?.ok) throw new Error(data?.error || "Nie udało się odrzucić.");
+    setView({ head: "Odrzucono", text: "Zaproszenie zostało odrzucone." });
+    clearActions();
+  } catch (e) {
+    console.error(e);
+    setView({ head: "Błąd", text: "Nie udało się odrzucić zaproszenia." });
+  }
+}
+
+async function handleSubInvite(data, user) {
+  const head = buildSubHeading(data);
+  const expectedEmail = normalizeEmail(data.subscriber_email);
+  const isActive = data.status === "pending";
+  const hasAccountInvite = Boolean(data.subscriber_user_id);
+  const userEmail = normalizeEmail(user?.email);
+
+  if (user) {
+    const matchById = data.subscriber_user_id && user.id === data.subscriber_user_id;
+    const matchByEmail = !data.subscriber_user_id && expectedEmail && userEmail === expectedEmail;
+    if (!(matchById || matchByEmail)) {
+      showMismatch(head, data.subscriber_email);
+      return;
+    }
+
+    if (!isActive) {
+      showExpired(head);
+      return;
+    }
+
+    setView({ head, text: "Żeby zaakceptować przejdź do Centrum Sondaży." });
+    clearActions();
+    addAction("Centrum Sondaży", "gold", redirectToHub);
+    showEmailInput(false);
+    return;
+  }
+
+  if (!isActive) {
+    if (hasAccountInvite) {
+      showExpired(head);
+      return;
+    }
+
+    setView({ head, text: "Jeśli chcesz zasubskrybować podaj adres email." });
+    showEmailInput(true);
+    clearActions();
+    addAction("Subskrybuj", "gold", async () => subscribeByEmail());
+    return;
+  }
+
+  if (hasAccountInvite) {
+    setView({ head, text: "Żeby zaakceptować musisz się zalogować." });
+    clearActions();
+    addAction("Zaloguj", "gold", redirectToLogin);
+    showEmailInput(false);
+    return;
+  }
+
+  setView({ head, text: "Zaproszenie do subskrypcji jest aktywne." });
+  clearActions();
+  showEmailInput(false);
+  addAction("Akceptuj", "gold", async () => acceptSubDirect(data.subscriber_email));
+  addAction("Odrzuć", "danger", async () => declineSub());
+}
+
+async function handleTaskInvite(data, user) {
+  const head = buildTaskHeading(data);
+  const expectedEmail = normalizeEmail(data.recipient_email);
+  const isActive = ["pending", "opened"].includes(data.status);
+  const hasAccountInvite = Boolean(data.recipient_user_id);
+  const userEmail = normalizeEmail(user?.email);
+
+  if (user) {
+    const matchById = data.recipient_user_id && user.id === data.recipient_user_id;
+    const matchByEmail = !data.recipient_user_id && expectedEmail && userEmail === expectedEmail;
+    if (!(matchById || matchByEmail)) {
+      showMismatch(head, data.recipient_email);
+      return;
+    }
+
+    if (!isActive) {
+      showExpired(head);
+      return;
+    }
+
+    setView({ head, text: "Żeby zaakceptować przejdź do Centrum Sondaży." });
+    clearActions();
+    addAction("Centrum Sondaży", "gold", redirectToHub);
+    showEmailInput(false);
+    return;
+  }
+
+  if (!isActive) {
+    showExpired(head);
+    return;
+  }
+
+  if (hasAccountInvite) {
+    setView({ head, text: "Żeby zagłosować musisz się zalogować." });
+    clearActions();
+    addAction("Zaloguj", "gold", redirectToLogin);
+    showEmailInput(false);
+    return;
+  }
+
+  setView({ head, text: "Zaproszenie do głosowania jest aktywne." });
+  clearActions();
+  showEmailInput(false);
+  addAction("Głosuj", "gold", () => openVote(data.poll_type));
+  addAction("Odrzuć", "danger", async () => declineTask());
+}
+
+async function init() {
+  if (!goToken) {
+    setView({ head: "Brak linku", text: "Brakuje tokenu zaproszenia." });
+    return;
+  }
+
+  const user = await getUser();
+  try {
+    const data = await resolveToken();
+    if (!data?.ok) {
+      setView({ head: "Link nieważny", text: "Link jest nieważny lub nieaktywny." });
+      return;
+    }
+
+    if (data.kind === "sub") {
+      await handleSubInvite(data, user);
+      return;
+    }
+
+    if (data.kind === "task") {
+      await handleTaskInvite(data, user);
+      return;
+    }
+
+    setView({ head: "Błąd", text: "Nie udało się rozpoznać zaproszenia." });
+  } catch (e) {
+    console.error(e);
+    setView({ head: "Błąd", text: "Nie udało się otworzyć zaproszenia." });
+  }
+}
+
+btnEmailNext?.addEventListener("click", async () => {
+  if (!goToken) return;
+  await subscribeByEmail();
 });
 
-if (taskToken) {
-  handleTask();
-} else if (subToken) {
-  handleSub();
-} else {
-  setView({ head: "Brak linku", text: "Brakuje tokenu zaproszenia." });
-}
+init();

--- a/js/pages/polls-hub.js
+++ b/js/pages/polls-hub.js
@@ -18,6 +18,14 @@ const tabPolls = $("tabPolls");
 const tabSubs = $("tabSubs");
 const panelPolls = $("panelPolls");
 const panelSubs = $("panelSubs");
+const tabPollsMobile = $("tabPollsMobile");
+const tabTasksMobile = $("tabTasksMobile");
+const tabSubscribersMobile = $("tabSubscribersMobile");
+const tabSubscriptionsMobile = $("tabSubscriptionsMobile");
+const panelPollsMobile = $("panelPollsMobile");
+const panelTasksMobile = $("panelTasksMobile");
+const panelSubscribersMobile = $("panelSubscribersMobile");
+const panelSubscriptionsMobile = $("panelSubscriptionsMobile");
 
 const MAIL_FUNCTION_URL = `${SUPABASE_URL}/functions/v1/send-mail`;
 
@@ -216,16 +224,17 @@ async function sendMail({ to, subject, html }) {
 
 async function sendSubscriptionEmail({ to, link, ownerLabel }) {
   const actionUrl = mailLink(link);
+  const title = `Zaproszenie do subskrypcji od użytkownika ${ownerLabel}`;
   const html = buildMailHtml({
-    title: "Zaproszenie do subskrypcji",
+    title,
     subtitle: "Centrum sondaży",
-    body: `Użytkownik <strong>${ownerLabel}</strong> zaprasza Cię do subskrypcji. Kliknij przycisk, aby zaakceptować zaproszenie.`,
-    actionLabel: "Akceptuj zaproszenie",
+    body: `Użytkownik <strong>${ownerLabel}</strong> zaprasza Cię do subskrypcji. Kliknij przycisk, aby zobaczyć zaproszenie.`,
+    actionLabel: "Zobacz zaproszenie",
     actionUrl,
   });
   await sendMail({
     to,
-    subject: "Zaproszenie do subskrypcji — Familiada",
+    subject: title,
     html,
   });
 }
@@ -265,6 +274,23 @@ function setActiveTab(tab) {
   tabSubs?.classList.toggle("active", !isPolls);
   panelPolls?.classList.toggle("active", isPolls);
   panelSubs?.classList.toggle("active", !isPolls);
+}
+
+function setActiveMobileTab(tab) {
+  const isPolls = tab === "polls";
+  const isTasks = tab === "tasks";
+  const isSubscribers = tab === "subscribers";
+  const isSubscriptions = tab === "subscriptions";
+
+  tabPollsMobile?.classList.toggle("active", isPolls);
+  tabTasksMobile?.classList.toggle("active", isTasks);
+  tabSubscribersMobile?.classList.toggle("active", isSubscribers);
+  tabSubscriptionsMobile?.classList.toggle("active", isSubscriptions);
+
+  panelPollsMobile?.classList.toggle("active", isPolls);
+  panelTasksMobile?.classList.toggle("active", isTasks);
+  panelSubscribersMobile?.classList.toggle("active", isSubscribers);
+  panelSubscriptionsMobile?.classList.toggle("active", isSubscriptions);
 }
 
 function updateBadges() {
@@ -1101,6 +1127,12 @@ document.addEventListener("DOMContentLoaded", async () => {
   tabPolls?.addEventListener("click", () => setActiveTab("polls"));
   tabSubs?.addEventListener("click", () => setActiveTab("subs"));
   setActiveTab("polls");
+
+  tabPollsMobile?.addEventListener("click", () => setActiveMobileTab("polls"));
+  tabTasksMobile?.addEventListener("click", () => setActiveMobileTab("tasks"));
+  tabSubscribersMobile?.addEventListener("click", () => setActiveMobileTab("subscribers"));
+  tabSubscriptionsMobile?.addEventListener("click", () => setActiveMobileTab("subscriptions"));
+  setActiveMobileTab("polls");
 
   btnShare?.addEventListener("click", openShareModal);
   btnShareMobile?.addEventListener("click", openShareModal);

--- a/polls-hub.html
+++ b/polls-hub.html
@@ -148,78 +148,129 @@
     </section>
 
     <section class="hub-mobile">
-      <div class="card hub-card">
-        <div class="hub-col-head">
-          <div>
-            <div class="hub-col-title">Moje sondaże</div>
-            <div class="hub-col-hint">Kliknij kafelek, aby go zaznaczyć.</div>
-          </div>
-          <div class="hub-controls">
-            <select class="inp sm" id="sortPollsMobile"></select>
-            <div class="hub-toggle" data-kind="polls">
-              <button class="btn xs" data-toggle="current">Aktualne</button>
-              <button class="btn xs" data-toggle="archive">Archiwalne</button>
+      <div class="tabs-card hub-tabs hub-tabs-mobile" id="hubTabsMobile">
+        <div class="tabs-strip">
+          <div class="tab-slot slot-mobile-polls">
+            <button class="tab-label" id="tabPollsMobile" type="button">Sondaże</button>
+            <div class="tab-wrapper">
+              <div class="tab-active">Sondaże</div>
+              <div class="tab-corner tab-corner-left"></div>
+              <div class="tab-corner tab-corner-right"></div>
             </div>
-            <button class="btn xs" id="btnShareMobile" type="button" disabled>Udostępnij</button>
-            <button class="btn xs" id="btnDetailsMobile" type="button" disabled>Szczegóły</button>
+          </div>
+          <div class="tab-slot slot-mobile-tasks">
+            <button class="tab-label" id="tabTasksMobile" type="button">
+              Zadania
+              <span class="hub-tab-badge is-empty" data-badge="tasks"></span>
+            </button>
+            <div class="tab-wrapper">
+              <div class="tab-active">
+                Zadania
+                <span class="hub-tab-badge is-empty" data-badge="tasks"></span>
+              </div>
+              <div class="tab-corner tab-corner-left"></div>
+              <div class="tab-corner tab-corner-right"></div>
+            </div>
+          </div>
+          <div class="tab-slot slot-mobile-subscribers">
+            <button class="tab-label" id="tabSubscribersMobile" type="button">Subskrybenci</button>
+            <div class="tab-wrapper">
+              <div class="tab-active">Subskrybenci</div>
+              <div class="tab-corner tab-corner-left"></div>
+              <div class="tab-corner tab-corner-right"></div>
+            </div>
+          </div>
+          <div class="tab-slot slot-mobile-subscriptions">
+            <button class="tab-label" id="tabSubscriptionsMobile" type="button">
+              Subskrypcje
+              <span class="hub-tab-badge is-empty" data-badge="subs"></span>
+            </button>
+            <div class="tab-wrapper">
+              <div class="tab-active">
+                Subskrypcje
+                <span class="hub-tab-badge is-empty" data-badge="subs"></span>
+              </div>
+              <div class="tab-corner tab-corner-left"></div>
+              <div class="tab-corner tab-corner-right"></div>
+            </div>
           </div>
         </div>
-        <div class="hub-list" id="pollsListMobile"></div>
-      </div>
 
-      <div class="card hub-card">
-        <div class="hub-col-head">
-          <div>
-            <div class="hub-col-title">Zadania</div>
-            <div class="hub-col-hint">Dwuklik otwiera głosowanie.</div>
-          </div>
-          <div class="hub-controls">
-            <select class="inp sm" id="sortTasksMobile"></select>
-            <div class="hub-toggle" data-kind="tasks">
-              <button class="btn xs" data-toggle="current">Aktualne</button>
-              <button class="btn xs" data-toggle="archive">Archiwalne</button>
+        <div class="card hub-card">
+          <div class="hub-tab-panel hub-mobile-panel" id="panelPollsMobile">
+            <div class="hub-col-head">
+              <div>
+                <div class="hub-col-title">Moje sondaże</div>
+                <div class="hub-col-hint">Kliknij kafelek, aby go zaznaczyć.</div>
+              </div>
+              <div class="hub-controls">
+                <select class="inp sm" id="sortPollsMobile"></select>
+                <div class="hub-toggle" data-kind="polls">
+                  <button class="btn xs" data-toggle="current">Aktualne</button>
+                  <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                </div>
+                <button class="btn xs" id="btnShareMobile" type="button" disabled>Udostępnij</button>
+                <button class="btn xs" id="btnDetailsMobile" type="button" disabled>Szczegóły</button>
+              </div>
             </div>
+            <div class="hub-list" id="pollsListMobile"></div>
           </div>
-        </div>
-        <div class="hub-list" id="tasksListMobile"></div>
-      </div>
 
-      <div class="card hub-card">
-        <div class="hub-col-head">
-          <div>
-            <div class="hub-col-title">Moi subskrybenci</div>
-            <div class="hub-col-hint">Zaproś nowych i zarządzaj zaproszeniami.</div>
-          </div>
-          <div class="hub-controls">
-            <select class="inp sm" id="sortSubscribersMobile"></select>
-            <div class="hub-toggle" data-kind="subscribers">
-              <button class="btn xs" data-toggle="current">Aktualne</button>
-              <button class="btn xs" data-toggle="archive">Archiwalne</button>
+          <div class="hub-tab-panel hub-mobile-panel" id="panelTasksMobile">
+            <div class="hub-col-head">
+              <div>
+                <div class="hub-col-title">Zadania</div>
+                <div class="hub-col-hint">Dwuklik otwiera głosowanie.</div>
+              </div>
+              <div class="hub-controls">
+                <select class="inp sm" id="sortTasksMobile"></select>
+                <div class="hub-toggle" data-kind="tasks">
+                  <button class="btn xs" data-toggle="current">Aktualne</button>
+                  <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                </div>
+              </div>
             </div>
+            <div class="hub-list" id="tasksListMobile"></div>
           </div>
-        </div>
-        <div class="hub-invite">
-          <input class="inp" id="inviteInputMobile" placeholder="Email lub nazwa użytkownika"/>
-          <button class="btn xs gold" id="btnInviteMobile" type="button">Zaproś</button>
-        </div>
-        <div class="hub-list" id="subscribersListMobile"></div>
-      </div>
 
-      <div class="card hub-card">
-        <div class="hub-col-head">
-          <div>
-            <div class="hub-col-title">Moje subskrypcje</div>
-            <div class="hub-col-hint">Akceptuj zaproszenia od innych.</div>
-          </div>
-          <div class="hub-controls">
-            <select class="inp sm" id="sortSubscriptionsMobile"></select>
-            <div class="hub-toggle" data-kind="subscriptions">
-              <button class="btn xs" data-toggle="current">Aktualne</button>
-              <button class="btn xs" data-toggle="archive">Archiwalne</button>
+          <div class="hub-tab-panel hub-mobile-panel" id="panelSubscribersMobile">
+            <div class="hub-col-head">
+              <div>
+                <div class="hub-col-title">Moi subskrybenci</div>
+                <div class="hub-col-hint">Zaproś nowych i zarządzaj zaproszeniami.</div>
+              </div>
+              <div class="hub-controls">
+                <select class="inp sm" id="sortSubscribersMobile"></select>
+                <div class="hub-toggle" data-kind="subscribers">
+                  <button class="btn xs" data-toggle="current">Aktualne</button>
+                  <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                </div>
+              </div>
             </div>
+            <div class="hub-invite">
+              <input class="inp" id="inviteInputMobile" placeholder="Email lub nazwa użytkownika"/>
+              <button class="btn xs gold" id="btnInviteMobile" type="button">Zaproś</button>
+            </div>
+            <div class="hub-list" id="subscribersListMobile"></div>
+          </div>
+
+          <div class="hub-tab-panel hub-mobile-panel" id="panelSubscriptionsMobile">
+            <div class="hub-col-head">
+              <div>
+                <div class="hub-col-title">Moje subskrypcje</div>
+                <div class="hub-col-hint">Akceptuj zaproszenia od innych.</div>
+              </div>
+              <div class="hub-controls">
+                <select class="inp sm" id="sortSubscriptionsMobile"></select>
+                <div class="hub-toggle" data-kind="subscriptions">
+                  <button class="btn xs" data-toggle="current">Aktualne</button>
+                  <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                </div>
+              </div>
+            </div>
+            <div class="hub-list" id="subscriptionsListMobile"></div>
           </div>
         </div>
-        <div class="hub-list" id="subscriptionsListMobile"></div>
       </div>
     </section>
   </main>


### PR DESCRIPTION
### Motivation
- Improve handling of invitation tokens (tasks and subscriptions) so the UI behaves correctly depending on token kind, session ownership and recipient email.
- Provide clearer email CTA/subject and owner/poll context in the invite flow.
- Replace the stacked mobile layout in `polls-hub` with a 4-tab mobile UI matching the desktop tabs for easier navigation.

### Description
- Unified token handling in the front-end by introducing `goToken` and switching `poll-go.js` to call `poll_go_resolve`, then branch UI flows for `kind: sub` and `kind: task` with explicit cases for logged-in vs anonymous users, email mismatch, expired tokens and available actions (login, go to hub, accept, vote, decline). 
- Implemented helper functions and UX changes in `js/pages/poll-go.js` (email normalization, headings, mismatch/expired messages, subscribe-by-email fallback, use of `poll_go_subscribe_email` and `poll_sub_accept_email` via the unified token). 
- Extended DB resolution logic in `supabase/schema.sql` and migration `00000000000000_init.sql` so `poll_go_resolve` returns `owner_label` and `game_name`, and improved `poll_go_subscribe_email` to validate or create an email-based subscription when appropriate. 
- Updated subscription email content in `js/pages/polls-hub.js` to include the owner in the subject and change the CTA to "Zobacz zaproszenie" and subject accordingly. 
- Added mobile tabbed UI to `polls-hub.html`, wired mobile tab controls in `js/pages/polls-hub.js`, and adjusted styles in `css/polls-hub.css` to support compact tab headers and show the correct mobile panels and badges.

### Testing
- Render test: launched a local HTTP server and captured a mobile screenshot of `polls-hub.html` with Playwright to validate the new mobile tabs layout, which completed and produced an artifact (`artifacts/polls-hub-mobile-tabs.png`).
- Basic sanity: manual smoke checks via the updated front-end JS in a local browser context (server was started automatically for the screenshot); these checks completed without runtime errors from the automation run.
- No unit/integration test suite was executed against SQL functions in CI as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69875c00e3148321982ae7bb367004d6)