### PR TITLE
Add migration for poll-go updates and improve invite flows + mobile tabs

### DIFF
--- a/css/polls-hub.css
+++ b/css/polls-hub.css
@@ -227,8 +227,19 @@ body.polls-hub-body {
 
 .hub-mobile {
   display: none;
-  flex-direction: column;
-  gap: 14px;
+}
+
+.hub-tabs-mobile {
+  --tab-height: 44px;
+}
+
+.hub-tabs-mobile .tabs-strip {
+  gap: 8px;
+}
+
+.hub-tabs-mobile .tab-label {
+  font-size: 10px;
+  letter-spacing: .04em;
 }
 
 .hub-empty {
@@ -318,7 +329,7 @@ body.polls-hub-body {
   }
 
   .hub-mobile {
-    display: flex;
+    display: block;
   }
 
   .hub-grid {

--- a/js/pages/poll-go.js
+++ b/js/pages/poll-go.js
@@ -5,6 +5,7 @@ import { getUser } from "../core/auth.js";
 const qs = new URLSearchParams(location.search);
 const taskToken = qs.get("t");
 const subToken = qs.get("s");
+const goToken = taskToken || subToken;
 
 const $ = (id) => document.getElementById(id);
 
@@ -54,140 +55,240 @@ function redirectToHub() {
   location.href = url.toString();
 }
 
-async function handleTaskResolve(emailOverride) {
-  const { data, error } = await sb().rpc("poll_task_resolve", { p_token: taskToken, p_email: emailOverride || null });
+function normalizeEmail(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+async function resolveToken() {
+  const { data, error } = await sb().rpc("poll_go_resolve", { p_token: goToken });
   if (error) throw error;
   return data;
 }
 
-async function handleTask() {
-  const user = await getUser();
-  try {
-    const data = await handleTaskResolve();
-    if (!data?.ok) {
-      setView({ head: "Link nieważny", text: "Link jest nieważny lub nieaktywny." });
-      return;
-    }
-
-    if (data.requires_auth && !user) {
-      setView({ head: "Zaloguj się", text: "Zaloguj się, aby przejść do głosowania." });
-      clearActions();
-      addAction("Zaloguj się", "gold", redirectToLogin);
-      addAction("Wróć", "", () => history.back());
-      return;
-    }
-
-    if (data.needs_email) {
-      setView({ head: "Podaj e-mail", text: "Podaj e-mail, aby odebrać zaproszenie." });
-      showEmailInput(true);
-      clearActions();
-      addAction("Odrzuć", "danger", async () => declineTask());
-      return;
-    }
-
-    showEmailInput(false);
-    setView({ head: "Zadanie do głosowania", text: "Możesz przejść do głosowania lub odrzucić zadanie." });
-    clearActions();
-    addAction("Przejdź do głosowania", "gold", () => openVote(data.poll_type));
-    addAction("Odrzuć", "danger", async () => declineTask());
-  } catch (e) {
-    console.error(e);
-    setView({ head: "Błąd", text: "Nie udało się otworzyć zaproszenia." });
-  }
-}
-
 function openVote(type) {
   const page = type === "poll_points" ? "poll-points.html" : "poll-text.html";
-  location.href = `${page}?t=${encodeURIComponent(taskToken)}`;
+  location.href = `${page}?t=${encodeURIComponent(goToken)}`;
 }
 
 async function declineTask() {
   try {
-    await sb().rpc("poll_task_decline", { p_token: taskToken });
+    await sb().rpc("poll_task_decline", { p_token: goToken });
     setView({ head: "Odrzucono", text: "Zadanie zostało odrzucone." });
     clearActions();
-    addAction("Wróć", "", () => history.back());
   } catch (e) {
     console.error(e);
     setView({ head: "Błąd", text: "Nie udało się odrzucić zadania." });
   }
 }
 
-async function handleSub() {
-  const user = await getUser();
-  if (user) {
-    setView({ head: "Zaproszenie do subskrypcji", text: "Masz zaproszenie do subskrypcji. Przejdź do centrum sondaży, aby je obsłużyć." });
-    clearActions();
-    addAction("Przejdź do centrum", "gold", redirectToHub);
-    return;
-  }
-
-  setView({ head: "Zaproszenie do subskrypcji", text: "Podaj e-mail, aby zaakceptować zaproszenie." });
-  showEmailInput(true);
-  clearActions();
-  addAction("Subskrybuj", "gold", async () => acceptSubEmail());
-  addAction("Odrzuć", "danger", async () => declineSub());
-  if (hint) hint.textContent = "Możesz też zalogować się na konto, aby powiązać zaproszenie.";
+function buildSubHeading(data) {
+  const owner = data?.owner_label ? ` od użytkownika ${data.owner_label}` : "";
+  return `Zaproszenie do subskrypcji${owner}`;
 }
 
-async function acceptSubEmail() {
-  const email = emailInput?.value.trim();
-  if (!email) {
-    setView({ head: "Brak e-maila", text: "Podaj poprawny adres e-mail." });
-    return;
-  }
+function buildTaskHeading(data) {
+  const name = data?.game_name ? `„${data.game_name}”` : "sondażu";
+  const owner = data?.owner_label ? ` od użytkownika ${data.owner_label}` : "";
+  return `Zaproszenie do głosowania w ${name}${owner}`;
+}
+
+function showMismatch(head, expectedEmail) {
+  const emailText = expectedEmail || "adresata zaproszenia";
+  setView({
+    head,
+    text: `Zaproszenie Ciebie nie dotyczy, zaloguj się jako ${emailText} i spróbuj ponownie.`,
+  });
+  clearActions();
+  showEmailInput(false);
+}
+
+function showExpired(head) {
+  setView({ head, text: "Zaproszenie zostało wykorzystane." });
+  clearActions();
+  showEmailInput(false);
+}
+
+async function acceptSubDirect(email) {
   try {
-    const { data, error } = await sb().rpc("poll_sub_accept_email", { p_token: subToken, p_email: email });
+    const { data, error } = await sb().rpc("poll_sub_accept_email", { p_token: goToken, p_email: email });
     if (error) throw error;
     if (!data?.ok) throw new Error(data?.error || "Nie udało się zaakceptować.");
     setView({ head: "Subskrypcja aktywna", text: "Zaproszenie zostało zaakceptowane." });
     clearActions();
-    addAction("Wróć", "", () => history.back());
   } catch (e) {
     console.error(e);
     setView({ head: "Błąd", text: "Nie udało się zaakceptować zaproszenia." });
   }
 }
 
-async function declineSub() {
-  try {
-    const { data, error } = await sb().rpc("poll_sub_decline", { p_token: subToken });
-    if (error) throw error;
-    if (!data?.ok) throw new Error(data?.error || "Nie udało się odrzucić.");
-    setView({ head: "Odrzucono", text: "Zaproszenie zostało odrzucone." });
-    clearActions();
-    addAction("Wróć", "", () => history.back());
-  } catch (e) {
-    console.error(e);
-    setView({ head: "Błąd", text: "Nie udało się odrzucić zaproszenia." });
-  }
-}
-
-btnEmailNext?.addEventListener("click", async () => {
-  if (!taskToken) return;
+async function subscribeByEmail() {
   const email = emailInput?.value.trim();
   if (!email) {
     setView({ head: "Brak e-maila", text: "Podaj poprawny adres e-mail." });
     return;
   }
   try {
-    const data = await handleTaskResolve(email);
-    if (!data?.ok) throw new Error("invalid");
-    showEmailInput(false);
-    setView({ head: "Zadanie do głosowania", text: "Możesz przejść do głosowania lub odrzucić zadanie." });
+    const { data, error } = await sb().rpc("poll_go_subscribe_email", { p_token: goToken, p_email: email });
+    if (error) throw error;
+    if (!data) throw new Error("Nie udało się zasubskrybować.");
+    setView({ head: "Subskrypcja aktywna", text: "Subskrypcja została dodana." });
     clearActions();
-    addAction("Przejdź do głosowania", "gold", () => openVote(data.poll_type));
-    addAction("Odrzuć", "danger", async () => declineTask());
+    showEmailInput(false);
   } catch (e) {
     console.error(e);
-    setView({ head: "Błąd", text: "Nie udało się potwierdzić e-maila." });
+    setView({ head: "Błąd", text: "Nie udało się dodać subskrypcji." });
   }
+}
+
+async function declineSub() {
+  try {
+    const { data, error } = await sb().rpc("poll_sub_decline", { p_token: goToken });
+    if (error) throw error;
+    if (!data?.ok) throw new Error(data?.error || "Nie udało się odrzucić.");
+    setView({ head: "Odrzucono", text: "Zaproszenie zostało odrzucone." });
+    clearActions();
+  } catch (e) {
+    console.error(e);
+    setView({ head: "Błąd", text: "Nie udało się odrzucić zaproszenia." });
+  }
+}
+
+async function handleSubInvite(data, user) {
+  const head = buildSubHeading(data);
+  const expectedEmail = normalizeEmail(data.subscriber_email);
+  const isActive = data.status === "pending";
+  const hasAccountInvite = Boolean(data.subscriber_user_id);
+  const userEmail = normalizeEmail(user?.email);
+
+  if (user) {
+    const matchById = data.subscriber_user_id && user.id === data.subscriber_user_id;
+    const matchByEmail = !data.subscriber_user_id && expectedEmail && userEmail === expectedEmail;
+    if (!(matchById || matchByEmail)) {
+      showMismatch(head, data.subscriber_email);
+      return;
+    }
+
+    if (!isActive) {
+      showExpired(head);
+      return;
+    }
+
+    setView({ head, text: "Żeby zaakceptować przejdź do Centrum Sondaży." });
+    clearActions();
+    addAction("Centrum Sondaży", "gold", redirectToHub);
+    showEmailInput(false);
+    return;
+  }
+
+  if (!isActive) {
+    if (hasAccountInvite) {
+      showExpired(head);
+      return;
+    }
+
+    setView({ head, text: "Jeśli chcesz zasubskrybować podaj adres email." });
+    showEmailInput(true);
+    clearActions();
+    addAction("Subskrybuj", "gold", async () => subscribeByEmail());
+    return;
+  }
+
+  if (hasAccountInvite) {
+    setView({ head, text: "Żeby zaakceptować musisz się zalogować." });
+    clearActions();
+    addAction("Zaloguj", "gold", redirectToLogin);
+    showEmailInput(false);
+    return;
+  }
+
+  setView({ head, text: "Zaproszenie do subskrypcji jest aktywne." });
+  clearActions();
+  showEmailInput(false);
+  addAction("Akceptuj", "gold", async () => acceptSubDirect(data.subscriber_email));
+  addAction("Odrzuć", "danger", async () => declineSub());
+}
+
+async function handleTaskInvite(data, user) {
+  const head = buildTaskHeading(data);
+  const expectedEmail = normalizeEmail(data.recipient_email);
+  const isActive = ["pending", "opened"].includes(data.status);
+  const hasAccountInvite = Boolean(data.recipient_user_id);
+  const userEmail = normalizeEmail(user?.email);
+
+  if (user) {
+    const matchById = data.recipient_user_id && user.id === data.recipient_user_id;
+    const matchByEmail = !data.recipient_user_id && expectedEmail && userEmail === expectedEmail;
+    if (!(matchById || matchByEmail)) {
+      showMismatch(head, data.recipient_email);
+      return;
+    }
+
+    if (!isActive) {
+      showExpired(head);
+      return;
+    }
+
+    setView({ head, text: "Żeby zaakceptować przejdź do Centrum Sondaży." });
+    clearActions();
+    addAction("Centrum Sondaży", "gold", redirectToHub);
+    showEmailInput(false);
+    return;
+  }
+
+  if (!isActive) {
+    showExpired(head);
+    return;
+  }
+
+  if (hasAccountInvite) {
+    setView({ head, text: "Żeby zagłosować musisz się zalogować." });
+    clearActions();
+    addAction("Zaloguj", "gold", redirectToLogin);
+    showEmailInput(false);
+    return;
+  }
+
+  setView({ head, text: "Zaproszenie do głosowania jest aktywne." });
+  clearActions();
+  showEmailInput(false);
+  addAction("Głosuj", "gold", () => openVote(data.poll_type));
+  addAction("Odrzuć", "danger", async () => declineTask());
+}
+
+async function init() {
+  if (!goToken) {
+    setView({ head: "Brak linku", text: "Brakuje tokenu zaproszenia." });
+    return;
+  }
+
+  const user = await getUser();
+  try {
+    const data = await resolveToken();
+    if (!data?.ok) {
+      setView({ head: "Link nieważny", text: "Link jest nieważny lub nieaktywny." });
+      return;
+    }
+
+    if (data.kind === "sub") {
+      await handleSubInvite(data, user);
+      return;
+    }
+
+    if (data.kind === "task") {
+      await handleTaskInvite(data, user);
+      return;
+    }
+
+    setView({ head: "Błąd", text: "Nie udało się rozpoznać zaproszenia." });
+  } catch (e) {
+    console.error(e);
+    setView({ head: "Błąd", text: "Nie udało się otworzyć zaproszenia." });
+  }
+}
+
+btnEmailNext?.addEventListener("click", async () => {
+  if (!goToken) return;
+  await subscribeByEmail();
 });
 
-if (taskToken) {
-  handleTask();
-} else if (subToken) {
-  handleSub();
-} else {
-  setView({ head: "Brak linku", text: "Brakuje tokenu zaproszenia." });
-}
+init();

--- a/js/pages/polls-hub.js
+++ b/js/pages/polls-hub.js
@@ -18,6 +18,14 @@ const tabPolls = $("tabPolls");
 const tabSubs = $("tabSubs");
 const panelPolls = $("panelPolls");
 const panelSubs = $("panelSubs");
+const tabPollsMobile = $("tabPollsMobile");
+const tabTasksMobile = $("tabTasksMobile");
+const tabSubscribersMobile = $("tabSubscribersMobile");
+const tabSubscriptionsMobile = $("tabSubscriptionsMobile");
+const panelPollsMobile = $("panelPollsMobile");
+const panelTasksMobile = $("panelTasksMobile");
+const panelSubscribersMobile = $("panelSubscribersMobile");
+const panelSubscriptionsMobile = $("panelSubscriptionsMobile");
 
 const MAIL_FUNCTION_URL = `${SUPABASE_URL}/functions/v1/send-mail`;
 
@@ -216,16 +224,17 @@ async function sendMail({ to, subject, html }) {
 
 async function sendSubscriptionEmail({ to, link, ownerLabel }) {
   const actionUrl = mailLink(link);
+  const title = `Zaproszenie do subskrypcji od użytkownika ${ownerLabel}`;
   const html = buildMailHtml({
-    title: "Zaproszenie do subskrypcji",
+    title,
     subtitle: "Centrum sondaży",
-    body: `Użytkownik <strong>${ownerLabel}</strong> zaprasza Cię do subskrypcji. Kliknij przycisk, aby zaakceptować zaproszenie.`,
-    actionLabel: "Akceptuj zaproszenie",
+    body: `Użytkownik <strong>${ownerLabel}</strong> zaprasza Cię do subskrypcji. Kliknij przycisk, aby zobaczyć zaproszenie.`,
+    actionLabel: "Zobacz zaproszenie",
     actionUrl,
   });
   await sendMail({
     to,
-    subject: "Zaproszenie do subskrypcji — Familiada",
+    subject: title,
     html,
   });
 }
@@ -265,6 +274,23 @@ function setActiveTab(tab) {
   tabSubs?.classList.toggle("active", !isPolls);
   panelPolls?.classList.toggle("active", isPolls);
   panelSubs?.classList.toggle("active", !isPolls);
+}
+
+function setActiveMobileTab(tab) {
+  const isPolls = tab === "polls";
+  const isTasks = tab === "tasks";
+  const isSubscribers = tab === "subscribers";
+  const isSubscriptions = tab === "subscriptions";
+
+  tabPollsMobile?.classList.toggle("active", isPolls);
+  tabTasksMobile?.classList.toggle("active", isTasks);
+  tabSubscribersMobile?.classList.toggle("active", isSubscribers);
+  tabSubscriptionsMobile?.classList.toggle("active", isSubscriptions);
+
+  panelPollsMobile?.classList.toggle("active", isPolls);
+  panelTasksMobile?.classList.toggle("active", isTasks);
+  panelSubscribersMobile?.classList.toggle("active", isSubscribers);
+  panelSubscriptionsMobile?.classList.toggle("active", isSubscriptions);
 }
 
 function updateBadges() {
@@ -1101,6 +1127,12 @@ document.addEventListener("DOMContentLoaded", async () => {
   tabPolls?.addEventListener("click", () => setActiveTab("polls"));
   tabSubs?.addEventListener("click", () => setActiveTab("subs"));
   setActiveTab("polls");
+
+  tabPollsMobile?.addEventListener("click", () => setActiveMobileTab("polls"));
+  tabTasksMobile?.addEventListener("click", () => setActiveMobileTab("tasks"));
+  tabSubscribersMobile?.addEventListener("click", () => setActiveMobileTab("subscribers"));
+  tabSubscriptionsMobile?.addEventListener("click", () => setActiveMobileTab("subscriptions"));
+  setActiveMobileTab("polls");
 
   btnShare?.addEventListener("click", openShareModal);
   btnShareMobile?.addEventListener("click", openShareModal);

--- a/polls-hub.html
+++ b/polls-hub.html
@@ -148,78 +148,129 @@
     </section>
 
     <section class="hub-mobile">
-      <div class="card hub-card">
-        <div class="hub-col-head">
-          <div>
-            <div class="hub-col-title">Moje sondaże</div>
-            <div class="hub-col-hint">Kliknij kafelek, aby go zaznaczyć.</div>
-          </div>
-          <div class="hub-controls">
-            <select class="inp sm" id="sortPollsMobile"></select>
-            <div class="hub-toggle" data-kind="polls">
-              <button class="btn xs" data-toggle="current">Aktualne</button>
-              <button class="btn xs" data-toggle="archive">Archiwalne</button>
+      <div class="tabs-card hub-tabs hub-tabs-mobile" id="hubTabsMobile">
+        <div class="tabs-strip">
+          <div class="tab-slot slot-mobile-polls">
+            <button class="tab-label" id="tabPollsMobile" type="button">Sondaże</button>
+            <div class="tab-wrapper">
+              <div class="tab-active">Sondaże</div>
+              <div class="tab-corner tab-corner-left"></div>
+              <div class="tab-corner tab-corner-right"></div>
             </div>
-            <button class="btn xs" id="btnShareMobile" type="button" disabled>Udostępnij</button>
-            <button class="btn xs" id="btnDetailsMobile" type="button" disabled>Szczegóły</button>
+          </div>
+          <div class="tab-slot slot-mobile-tasks">
+            <button class="tab-label" id="tabTasksMobile" type="button">
+              Zadania
+              <span class="hub-tab-badge is-empty" data-badge="tasks"></span>
+            </button>
+            <div class="tab-wrapper">
+              <div class="tab-active">
+                Zadania
+                <span class="hub-tab-badge is-empty" data-badge="tasks"></span>
+              </div>
+              <div class="tab-corner tab-corner-left"></div>
+              <div class="tab-corner tab-corner-right"></div>
+            </div>
+          </div>
+          <div class="tab-slot slot-mobile-subscribers">
+            <button class="tab-label" id="tabSubscribersMobile" type="button">Subskrybenci</button>
+            <div class="tab-wrapper">
+              <div class="tab-active">Subskrybenci</div>
+              <div class="tab-corner tab-corner-left"></div>
+              <div class="tab-corner tab-corner-right"></div>
+            </div>
+          </div>
+          <div class="tab-slot slot-mobile-subscriptions">
+            <button class="tab-label" id="tabSubscriptionsMobile" type="button">
+              Subskrypcje
+              <span class="hub-tab-badge is-empty" data-badge="subs"></span>
+            </button>
+            <div class="tab-wrapper">
+              <div class="tab-active">
+                Subskrypcje
+                <span class="hub-tab-badge is-empty" data-badge="subs"></span>
+              </div>
+              <div class="tab-corner tab-corner-left"></div>
+              <div class="tab-corner tab-corner-right"></div>
+            </div>
           </div>
         </div>
-        <div class="hub-list" id="pollsListMobile"></div>
-      </div>
 
-      <div class="card hub-card">
-        <div class="hub-col-head">
-          <div>
-            <div class="hub-col-title">Zadania</div>
-            <div class="hub-col-hint">Dwuklik otwiera głosowanie.</div>
-          </div>
-          <div class="hub-controls">
-            <select class="inp sm" id="sortTasksMobile"></select>
-            <div class="hub-toggle" data-kind="tasks">
-              <button class="btn xs" data-toggle="current">Aktualne</button>
-              <button class="btn xs" data-toggle="archive">Archiwalne</button>
+        <div class="card hub-card">
+          <div class="hub-tab-panel hub-mobile-panel" id="panelPollsMobile">
+            <div class="hub-col-head">
+              <div>
+                <div class="hub-col-title">Moje sondaże</div>
+                <div class="hub-col-hint">Kliknij kafelek, aby go zaznaczyć.</div>
+              </div>
+              <div class="hub-controls">
+                <select class="inp sm" id="sortPollsMobile"></select>
+                <div class="hub-toggle" data-kind="polls">
+                  <button class="btn xs" data-toggle="current">Aktualne</button>
+                  <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                </div>
+                <button class="btn xs" id="btnShareMobile" type="button" disabled>Udostępnij</button>
+                <button class="btn xs" id="btnDetailsMobile" type="button" disabled>Szczegóły</button>
+              </div>
             </div>
+            <div class="hub-list" id="pollsListMobile"></div>
           </div>
-        </div>
-        <div class="hub-list" id="tasksListMobile"></div>
-      </div>
 
-      <div class="card hub-card">
-        <div class="hub-col-head">
-          <div>
-            <div class="hub-col-title">Moi subskrybenci</div>
-            <div class="hub-col-hint">Zaproś nowych i zarządzaj zaproszeniami.</div>
-          </div>
-          <div class="hub-controls">
-            <select class="inp sm" id="sortSubscribersMobile"></select>
-            <div class="hub-toggle" data-kind="subscribers">
-              <button class="btn xs" data-toggle="current">Aktualne</button>
-              <button class="btn xs" data-toggle="archive">Archiwalne</button>
+          <div class="hub-tab-panel hub-mobile-panel" id="panelTasksMobile">
+            <div class="hub-col-head">
+              <div>
+                <div class="hub-col-title">Zadania</div>
+                <div class="hub-col-hint">Dwuklik otwiera głosowanie.</div>
+              </div>
+              <div class="hub-controls">
+                <select class="inp sm" id="sortTasksMobile"></select>
+                <div class="hub-toggle" data-kind="tasks">
+                  <button class="btn xs" data-toggle="current">Aktualne</button>
+                  <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                </div>
+              </div>
             </div>
+            <div class="hub-list" id="tasksListMobile"></div>
           </div>
-        </div>
-        <div class="hub-invite">
-          <input class="inp" id="inviteInputMobile" placeholder="Email lub nazwa użytkownika"/>
-          <button class="btn xs gold" id="btnInviteMobile" type="button">Zaproś</button>
-        </div>
-        <div class="hub-list" id="subscribersListMobile"></div>
-      </div>
 
-      <div class="card hub-card">
-        <div class="hub-col-head">
-          <div>
-            <div class="hub-col-title">Moje subskrypcje</div>
-            <div class="hub-col-hint">Akceptuj zaproszenia od innych.</div>
-          </div>
-          <div class="hub-controls">
-            <select class="inp sm" id="sortSubscriptionsMobile"></select>
-            <div class="hub-toggle" data-kind="subscriptions">
-              <button class="btn xs" data-toggle="current">Aktualne</button>
-              <button class="btn xs" data-toggle="archive">Archiwalne</button>
+          <div class="hub-tab-panel hub-mobile-panel" id="panelSubscribersMobile">
+            <div class="hub-col-head">
+              <div>
+                <div class="hub-col-title">Moi subskrybenci</div>
+                <div class="hub-col-hint">Zaproś nowych i zarządzaj zaproszeniami.</div>
+              </div>
+              <div class="hub-controls">
+                <select class="inp sm" id="sortSubscribersMobile"></select>
+                <div class="hub-toggle" data-kind="subscribers">
+                  <button class="btn xs" data-toggle="current">Aktualne</button>
+                  <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                </div>
+              </div>
             </div>
+            <div class="hub-invite">
+              <input class="inp" id="inviteInputMobile" placeholder="Email lub nazwa użytkownika"/>
+              <button class="btn xs gold" id="btnInviteMobile" type="button">Zaproś</button>
+            </div>
+            <div class="hub-list" id="subscribersListMobile"></div>
+          </div>
+
+          <div class="hub-tab-panel hub-mobile-panel" id="panelSubscriptionsMobile">
+            <div class="hub-col-head">
+              <div>
+                <div class="hub-col-title">Moje subskrypcje</div>
+                <div class="hub-col-hint">Akceptuj zaproszenia od innych.</div>
+              </div>
+              <div class="hub-controls">
+                <select class="inp sm" id="sortSubscriptionsMobile"></select>
+                <div class="hub-toggle" data-kind="subscriptions">
+                  <button class="btn xs" data-toggle="current">Aktualne</button>
+                  <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                </div>
+              </div>
+            </div>
+            <div class="hub-list" id="subscriptionsListMobile"></div>
           </div>
         </div>
-        <div class="hub-list" id="subscriptionsListMobile"></div>
       </div>
     </section>
   </main>

--- a/supabase/migrations/20250927120000_poll_go_updates.sql
+++ b/supabase/migrations/20250927120000_poll_go_updates.sql
@@ -1,0 +1,159 @@
+-- Update poll_go helpers with owner/poll labels and email subscription fallback
+
+CREATE OR REPLACE FUNCTION public.poll_go_resolve(p_token uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+declare
+  s record;
+  t record;
+begin
+  -- 1) subscription token?
+  select
+    ps.id,
+    ps.status,
+    ps.owner_id,
+    p.username as owner_label,
+    ps.subscriber_user_id,
+    ps.subscriber_email,
+    ps.opened_at
+  into s
+  from public.poll_subscriptions ps
+  left join public.profiles p on p.id = ps.owner_id
+  where ps.token = p_token
+  limit 1;
+
+  if found then
+    -- mark opened once
+    if s.opened_at is null then
+      update public.poll_subscriptions
+        set opened_at = now()
+      where id = s.id;
+    end if;
+
+    return jsonb_build_object(
+      'ok', true,
+      'kind', 'sub',
+      'sub_id', s.id,
+      'status', s.status,
+      'owner_id', s.owner_id,
+      'owner_label', s.owner_label,
+      'subscriber_user_id', s.subscriber_user_id,
+      'subscriber_email', s.subscriber_email
+    );
+  end if;
+
+  -- 2) task token?
+  select
+    pt.id,
+    pt.status,
+    pt.owner_id,
+    p.username as owner_label,
+    pt.recipient_user_id,
+    pt.recipient_email,
+    pt.game_id,
+    g.name as game_name,
+    pt.poll_type,
+    pt.share_key_poll,
+    pt.opened_at
+  into t
+  from public.poll_tasks pt
+  left join public.games g on g.id = pt.game_id
+  left join public.profiles p on p.id = pt.owner_id
+  where pt.token = p_token
+  limit 1;
+
+  if found then
+    -- mark opened once (only for pending)
+    if t.opened_at is null and t.status = 'pending' then
+      update public.poll_tasks
+        set status = 'opened',
+            opened_at = now()
+      where id = t.id;
+    end if;
+
+    return jsonb_build_object(
+      'ok', true,
+      'kind', 'task',
+      'task_id', t.id,
+      'status', t.status,
+      'owner_id', t.owner_id,
+      'owner_label', t.owner_label,
+      'recipient_user_id', t.recipient_user_id,
+      'recipient_email', t.recipient_email,
+      'game_id', t.game_id,
+      'game_name', t.game_name,
+      'poll_type', t.poll_type,
+      'share_key_poll', t.share_key_poll
+    );
+  end if;
+
+  return jsonb_build_object('ok', false, 'error', 'invalid_token');
+end;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.poll_go_subscribe_email(p_token uuid, p_email text)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+declare
+  v_email text;
+  v_sub public.poll_subscriptions%rowtype;
+begin
+  v_email := lower(trim(coalesce(p_email,'')));
+
+  if v_email = '' or position('@' in v_email) = 0 then
+    return false;
+  end if;
+
+  select * into v_sub
+  from public.poll_subscriptions s
+  where s.token = p_token
+  limit 1;
+
+  if not found then
+    return false;
+  end if;
+
+  if v_sub.status = 'pending'
+     and v_sub.subscriber_user_id is null
+     and v_sub.cancelled_at is null
+     and v_sub.declined_at is null then
+    if v_sub.subscriber_email is not null
+       and public._norm_email(v_sub.subscriber_email) <> public._norm_email(v_email) then
+      return false;
+    end if;
+
+    update public.poll_subscriptions s
+       set subscriber_email = coalesce(s.subscriber_email, v_email),
+           status = 'active',
+           opened_at = coalesce(s.opened_at, now()),
+           accepted_at = now()
+     where s.id = v_sub.id;
+
+    return found;
+  end if;
+
+  insert into public.poll_subscriptions (
+    owner_id,
+    subscriber_email,
+    status,
+    created_at,
+    opened_at,
+    accepted_at
+  )
+  values (
+    v_sub.owner_id,
+    v_email,
+    'active',
+    now(),
+    now(),
+    now()
+  );
+
+  return true;
+end;
+$function$;


### PR DESCRIPTION
### Motivation
- Avoid editing `schema.sql` / initial migration directly by moving `poll_go` SQL changes into a dedicated migration so migrations remain discoverable and reversible.
- Make the invite resolution flow single-entry (unified token) and more robust when handling invitation kinds, email mismatches and anonymous vs logged-in users.
- Improve UX for subscription emails by including the owner in the subject and CTA wording.
- Replace stacked mobile layout in the polls hub with a compact 4-tab mobile UI matching desktop tabs for easier navigation.

### Description
- Reverted direct edits to `supabase/schema.sql` and `supabase/migrations/00000000000000_init.sql` and added a new migration `supabase/migrations/20250927120000_poll_go_updates.sql` that implements `poll_go_resolve` and `poll_go_subscribe_email` with owner/poll labels and email subscription fallback.
- Rewrote `js/pages/poll-go.js` to use a unified `goToken`, call the new `poll_go_resolve` RPC, normalize email handling, and branch UI logic explicitly for `kind: sub` and `kind: task` including expired/mismatch/anonymous cases and email acceptance paths (`poll_go_subscribe_email` / `poll_sub_accept_email`).
- Updated `js/pages/polls-hub.js` to add mobile tab controls and to change subscription email content so the email subject includes the owner and the CTA reads "Zobacz zaproszenie".
- Modified `polls-hub.html` and `css/polls-hub.css` to add the 4-tab mobile UI, wire mobile panels and badges, and adjust mobile styles for compact headers.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69875c00e3148321982ae7bb367004d6)