### PR TITLE
Polls hub: UI polish, export gating & vote/task fixes

### DIFF
--- a/css/polls-hub.css
+++ b/css/polls-hub.css
@@ -92,6 +92,15 @@ body.polls-hub-body {
   gap: 4px;
 }
 
+.hub-toggle .btn.btn-toggle {
+  border-color: rgba(255,255,255,.18);
+  background: rgba(255,255,255,.04);
+  color: rgba(255,255,255,.7);
+  font-weight: 900;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
 .hub-toggle .btn.active {
   border-color: rgba(255,234,166,.45);
   background: rgba(255,234,166,.12);
@@ -102,6 +111,11 @@ body.polls-hub-body {
   display: grid;
   gap: 10px;
   min-height: 80px;
+}
+
+.hub-desktop .hub-list {
+  border-top: 1px solid rgba(255,255,255,.08);
+  padding-top: 10px;
 }
 
 .hub-item {
@@ -125,14 +139,24 @@ body.polls-hub-body {
   outline: 2px solid rgba(255,234,166,.45);
 }
 
+.hub-item > div {
+  min-width: 0;
+}
+
 .hub-item .hub-item-title {
   font-weight: 900;
   letter-spacing: .04em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .hub-item .hub-item-sub {
   font-size: 12px;
   opacity: .75;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .hub-item-actions {
@@ -230,16 +254,27 @@ body.polls-hub-body {
 }
 
 .hub-tabs-mobile {
-  --tab-height: 44px;
+  --tab-height: 40px;
+  --radius: 12px;
 }
 
 .hub-tabs-mobile .tabs-strip {
-  gap: 8px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px;
 }
 
 .hub-tabs-mobile .tab-label {
-  font-size: 10px;
-  letter-spacing: .04em;
+  font-size: 9px;
+  letter-spacing: .02em;
+  padding: 0 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hub-tabs-mobile .tab-active {
+  font-size: 9px;
+  padding: 0 4px;
 }
 
 .hub-empty {

--- a/js/pages/builder.js
+++ b/js/pages/builder.js
@@ -661,7 +661,7 @@ async function updateActionState() {
       canEdit,
       canPlay: !!cached.res.canPlay,
       canPoll: !!cached.res.canPoll,
-      canExport: true
+      canExport: !!cached.res.canExport
     });
     return;
   }
@@ -679,11 +679,11 @@ async function updateActionState() {
       canEdit,
       canPlay: !!st.canPlay,
       canPoll: !!st.canPoll,
-      canExport: true
+      canExport: !!st.canExport
     });
   } catch (e) {
     console.error("[builder] game_action_state error:", e);
-    setButtonsState({ hasSel: true, canEdit: false, canPlay: false, canPoll: false, canExport: true });
+    setButtonsState({ hasSel: true, canEdit: false, canPlay: false, canPoll: false, canExport: false });
   }
 }
 
@@ -834,7 +834,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         }
       }
 
-      location.href = `polls.html?id=${encodeURIComponent(selectedId)}`;
+      location.href = `polls.html?id=${encodeURIComponent(selectedId)}&from=builder`;
     } catch (e) {
       console.error(e);
       alert("Nie udało się otworzyć sondażu (błąd bazy).");

--- a/js/pages/poll-go.js
+++ b/js/pages/poll-go.js
@@ -15,7 +15,6 @@ const actions = $("actions");
 const hint = $("hint");
 const emailRow = $("emailRow");
 const emailInput = $("emailInput");
-const btnEmailNext = $("btnEmailNext");
 
 function setView({ head, text, hintText }) {
   if (title) title.textContent = head;
@@ -286,7 +285,9 @@ async function init() {
   }
 }
 
-btnEmailNext?.addEventListener("click", async () => {
+emailInput?.addEventListener("keydown", async (event) => {
+  if (event.key !== "Enter") return;
+  event.preventDefault();
   if (!goToken) return;
   await subscribeByEmail();
 });

--- a/js/pages/polls-hub.js
+++ b/js/pages/polls-hub.js
@@ -658,7 +658,7 @@ async function openPoll(poll) {
     alert("Dokończ grę w Moich grach");
     return;
   }
-  location.href = `polls.html?id=${encodeURIComponent(poll.game_id)}`;
+  location.href = `polls.html?id=${encodeURIComponent(poll.game_id)}&from=polls-hub`;
 }
 
 function extractToken(goUrl, key) {

--- a/js/pages/polls.js
+++ b/js/pages/polls.js
@@ -6,6 +6,7 @@ import QRCode from "https://cdn.jsdelivr.net/npm/qrcode@1.5.3/+esm";
 
 const qs = new URLSearchParams(location.search);
 const gameId = qs.get("id");
+const from = qs.get("from");
 
 const $ = (id) => document.getElementById(id);
 
@@ -50,6 +51,7 @@ let liveTimer = null;
 let liveBusy = false;
 
 let uiTextCloseOpen = false;
+const backTarget = from === "polls-hub" ? "polls-hub.html" : "builder.html";
 
 // ===== Live diff cache (żeby nie mrugało) =====
 let liveSig_game = "";      // sygnatura stanu gry (status + poll_opened_at/poll_closed_at)
@@ -1303,6 +1305,7 @@ async function refresh() {
 document.addEventListener("DOMContentLoaded", async () => {
   const u = await requireAuth("index.html");
   if (who) who.textContent = u?.username || u?.email || "—";
+  if (btnBack) btnBack.textContent = from === "polls-hub" ? "← Centrum sondaży" : "← Moje gry";
 
 
   document.addEventListener("visibilitychange", () => {
@@ -1330,7 +1333,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       if (!ok) return;
       setTextCloseUi(false);
     }
-    location.href = "builder.html";
+    location.href = backTarget;
   });
   
   btnLogout?.addEventListener("click", async () => {

--- a/poll_go.html
+++ b/poll_go.html
@@ -25,7 +25,6 @@
 
       <div class="poll-go-email" id="emailRow" style="display:none;">
         <input class="inp" id="emailInput" placeholder="Podaj e-mail" type="email"/>
-        <button class="btn sm" id="btnEmailNext" type="button">Dalej</button>
       </div>
 
       <div class="poll-go-actions" id="actions"></div>

--- a/polls-hub.html
+++ b/polls-hub.html
@@ -16,17 +16,22 @@
 
 <body class="polls-hub-body">
   <header class="topbar">
-    <div class="left">
-      <button class="btn sm" id="btnBackToBuilder" type="button">← Moje gry</button>
-    </div>
-    <div class="brand">Centrum sondaży</div>
+    <div class="brand">FAMILIADA</div>
     <div class="right">
+      <button class="btn" id="btnBackToBuilder" type="button">← Moje gry</button>
       <span class="who" id="who">—</span>
       <button class="btn sm" id="btnLogout" type="button">Wyloguj</button>
     </div>
   </header>
 
   <main class="wrap">
+    <div class="bar">
+      <div>
+        <div class="title">Centrum sondaży</div>
+        <div class="hint">Zarządzaj sondażami oraz zaproszeniami do głosowania.</div>
+      </div>
+    </div>
+
     <section class="hub-desktop">
       <div class="tabs-card hub-tabs" id="hubTabs">
         <div class="tabs-strip">
@@ -73,8 +78,8 @@
                   <div class="hub-controls">
                     <select class="inp sm" id="sortPollsDesktop"></select>
                     <div class="hub-toggle" data-kind="polls">
-                      <button class="btn xs" data-toggle="current">Aktualne</button>
-                      <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                      <button class="btn xs btn-toggle" data-toggle="current">Aktualne</button>
+                      <button class="btn xs btn-toggle" data-toggle="archive">Archiwalne</button>
                     </div>
                     <button class="btn xs" id="btnShare" type="button" disabled>Udostępnij</button>
                     <button class="btn xs" id="btnDetails" type="button" disabled>Szczegóły</button>
@@ -92,8 +97,8 @@
                   <div class="hub-controls">
                     <select class="inp sm" id="sortTasksDesktop"></select>
                     <div class="hub-toggle" data-kind="tasks">
-                      <button class="btn xs" data-toggle="current">Aktualne</button>
-                      <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                      <button class="btn xs btn-toggle" data-toggle="current">Aktualne</button>
+                      <button class="btn xs btn-toggle" data-toggle="archive">Archiwalne</button>
                     </div>
                   </div>
                 </div>
@@ -113,8 +118,8 @@
                   <div class="hub-controls">
                     <select class="inp sm" id="sortSubscribersDesktop"></select>
                     <div class="hub-toggle" data-kind="subscribers">
-                      <button class="btn xs" data-toggle="current">Aktualne</button>
-                      <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                      <button class="btn xs btn-toggle" data-toggle="current">Aktualne</button>
+                      <button class="btn xs btn-toggle" data-toggle="archive">Archiwalne</button>
                     </div>
                   </div>
                 </div>
@@ -134,8 +139,8 @@
                   <div class="hub-controls">
                     <select class="inp sm" id="sortSubscriptionsDesktop"></select>
                     <div class="hub-toggle" data-kind="subscriptions">
-                      <button class="btn xs" data-toggle="current">Aktualne</button>
-                      <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                      <button class="btn xs btn-toggle" data-toggle="current">Aktualne</button>
+                      <button class="btn xs btn-toggle" data-toggle="archive">Archiwalne</button>
                     </div>
                   </div>
                 </div>
@@ -173,21 +178,21 @@
             </div>
           </div>
           <div class="tab-slot slot-mobile-subscribers">
-            <button class="tab-label" id="tabSubscribersMobile" type="button">Subskrybenci</button>
+            <button class="tab-label" id="tabSubscribersMobile" type="button">Subskryb.</button>
             <div class="tab-wrapper">
-              <div class="tab-active">Subskrybenci</div>
+              <div class="tab-active">Subskryb.</div>
               <div class="tab-corner tab-corner-left"></div>
               <div class="tab-corner tab-corner-right"></div>
             </div>
           </div>
           <div class="tab-slot slot-mobile-subscriptions">
             <button class="tab-label" id="tabSubscriptionsMobile" type="button">
-              Subskrypcje
+              Subskryp.
               <span class="hub-tab-badge is-empty" data-badge="subs"></span>
             </button>
             <div class="tab-wrapper">
               <div class="tab-active">
-                Subskrypcje
+                Subskryp.
                 <span class="hub-tab-badge is-empty" data-badge="subs"></span>
               </div>
               <div class="tab-corner tab-corner-left"></div>
@@ -206,8 +211,8 @@
               <div class="hub-controls">
                 <select class="inp sm" id="sortPollsMobile"></select>
                 <div class="hub-toggle" data-kind="polls">
-                  <button class="btn xs" data-toggle="current">Aktualne</button>
-                  <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                  <button class="btn xs btn-toggle" data-toggle="current">Aktualne</button>
+                  <button class="btn xs btn-toggle" data-toggle="archive">Archiwalne</button>
                 </div>
                 <button class="btn xs" id="btnShareMobile" type="button" disabled>Udostępnij</button>
                 <button class="btn xs" id="btnDetailsMobile" type="button" disabled>Szczegóły</button>
@@ -225,8 +230,8 @@
               <div class="hub-controls">
                 <select class="inp sm" id="sortTasksMobile"></select>
                 <div class="hub-toggle" data-kind="tasks">
-                  <button class="btn xs" data-toggle="current">Aktualne</button>
-                  <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                  <button class="btn xs btn-toggle" data-toggle="current">Aktualne</button>
+                  <button class="btn xs btn-toggle" data-toggle="archive">Archiwalne</button>
                 </div>
               </div>
             </div>
@@ -242,8 +247,8 @@
               <div class="hub-controls">
                 <select class="inp sm" id="sortSubscribersMobile"></select>
                 <div class="hub-toggle" data-kind="subscribers">
-                  <button class="btn xs" data-toggle="current">Aktualne</button>
-                  <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                  <button class="btn xs btn-toggle" data-toggle="current">Aktualne</button>
+                  <button class="btn xs btn-toggle" data-toggle="archive">Archiwalne</button>
                 </div>
               </div>
             </div>
@@ -263,8 +268,8 @@
               <div class="hub-controls">
                 <select class="inp sm" id="sortSubscriptionsMobile"></select>
                 <div class="hub-toggle" data-kind="subscriptions">
-                  <button class="btn xs" data-toggle="current">Aktualne</button>
-                  <button class="btn xs" data-toggle="archive">Archiwalne</button>
+                  <button class="btn xs btn-toggle" data-toggle="current">Aktualne</button>
+                  <button class="btn xs btn-toggle" data-toggle="archive">Archiwalne</button>
                 </div>
               </div>
             </div>

--- a/supabase/migrations/20250927140000_poll_hub_state_export.sql
+++ b/supabase/migrations/20250927140000_poll_hub_state_export.sql
@@ -1,0 +1,258 @@
+CREATE OR REPLACE FUNCTION public.game_action_state(p_game_id uuid)
+ RETURNS TABLE(game_id uuid, rev timestamp with time zone, can_edit boolean, needs_reset_warning boolean, can_play boolean, can_poll boolean, can_export boolean, reason_play text, reason_poll text)
+ LANGUAGE sql
+ STABLE
+AS $function$
+with g as (
+  select id, type, status, updated_at
+  from public.games
+  where id = p_game_id
+),
+qs as (
+  select id, ord
+  from public.questions
+  where game_id = p_game_id
+),
+ans as (
+  select
+    a.question_id,
+    count(*) as cnt,
+    min(coalesce(a.fixed_points,0)) as minp,
+    max(coalesce(a.fixed_points,0)) as maxp,
+    sum(coalesce(a.fixed_points,0)) as sump
+  from public.answers a
+  join qs on qs.id = a.question_id
+  group by a.question_id
+),
+agg as (
+  select
+    coalesce((select count(*) from qs), 0) as qn,
+    coalesce((select min(cnt) from ans), 0) as an_min,
+    coalesce((select max(cnt) from ans), 0) as an_max,
+    coalesce((select bool_or(sump > 100) from ans), false) as sum_too_big,
+    coalesce((select bool_or(minp < 0) from ans), false) as neg_pts,
+    coalesce((select bool_or(maxp > 100) from ans), false) as over_pts
+)
+select
+  g.id as game_id,
+  g.updated_at as rev,
+
+  /* EDIT — zgodnie z canEnterEdit() */
+  case
+    when g.type = 'prepared' then true
+    when g.status = 'poll_open' then false
+    else true
+  end as can_edit,
+
+  /* warning resetu tylko dla poll_* w READY */
+  (g.type <> 'prepared' and g.status = 'ready') as needs_reset_warning,
+
+  /* PLAY — zgodnie z validateGameReadyToPlay() */
+  case
+    when g.type in ('poll_text','poll_points') then (g.status = 'ready')
+    when g.type = 'prepared' then
+      (select qn from agg) >= 10
+      and (select an_min from agg) between 3 and 6
+      and (select an_max from agg) between 3 and 6
+      and not (select sum_too_big from agg)
+      and not (select neg_pts from agg)
+      and not (select over_pts from agg)
+    else false
+  end as can_play,
+
+  /* POLL — zgodnie z validatePollEntry() + validatePollReadyToOpen() */
+  case
+    when g.type = 'prepared' then false
+    when g.type = 'poll_text' then (select qn from agg) >= 10
+    when g.type = 'poll_points' then
+      (select qn from agg) >= 10
+      and (select an_min from agg) between 3 and 6
+      and (select an_max from agg) between 3 and 6
+    else false
+  end as can_poll,
+
+  /* eksport: blokuj gdy sondaż otwarty */
+  case
+    when g.status = 'poll_open' then false
+    else true
+  end as can_export,
+
+  /* reason_play (opcjonalnie) */
+  case
+    when g.type in ('poll_text','poll_points') and g.status <> 'ready'
+      then 'Gra dostępna dopiero po zamknięciu sondażu.'
+    when g.type = 'prepared' and (select qn from agg) < 10
+      then 'Musi być co najmniej 10 pytań.'
+    when g.type = 'prepared' and not ((select an_min from agg) between 3 and 6 and (select an_max from agg) between 3 and 6)
+      then 'Każde pytanie musi mieć 3–6 odpowiedzi.'
+    when g.type = 'prepared' and (select neg_pts from agg)
+      then 'Punkty nie mogą być ujemne.'
+    when g.type = 'prepared' and (select over_pts from agg)
+      then 'Odpowiedź nie może mieć > 100 pkt.'
+    when g.type = 'prepared' and (select sum_too_big from agg)
+      then 'Suma punktów w pytaniu nie może przekroczyć 100.'
+    else null
+  end as reason_play,
+
+  /* reason_poll (opcjonalnie) */
+  case
+    when g.type = 'prepared'
+      then 'Preparowany nie ma sondażu.'
+    when (g.type in ('poll_text','poll_points') and (select qn from agg) < 10)
+      then 'Musi być co najmniej 10 pytań.'
+    when g.type = 'poll_points' and not ((select an_min from agg) between 3 and 6 and (select an_max from agg) between 3 and 6)
+      then 'Każde pytanie musi mieć 3–6 odpowiedzi.'
+    else null
+  end as reason_poll
+from g, agg;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.polls_hub_list_polls()
+ RETURNS TABLE(game_id uuid, name text, poll_type game_type, created_at timestamp with time zone, poll_state text, sessions_total integer, open_questions integer, closed_questions integer, tasks_active integer, tasks_done integer, recipients_preview text[], share_key_poll text, share_kind text, anon_votes integer)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+begin
+  return query
+  with my_polls as (
+    select g.id, g.name, g.type, g.created_at, g.share_key_poll, g.status
+    from public.games g
+    where g.owner_id = auth.uid()
+      and g.type in ('poll_text'::public.game_type, 'poll_points'::public.game_type)
+  ),
+  sess as (
+    select
+      ps.game_id,
+      count(ps.id)::int as sessions_total,
+      count(ps.id) filter (where ps.is_open = true and ps.closed_at is null)::int as open_questions,
+      count(ps.id) filter (where ps.closed_at is not null)::int as closed_questions
+    from public.poll_sessions ps
+    group by ps.game_id
+  ),
+  tasks as (
+    select
+      pt.game_id,
+      count(*) filter (where pt.status in ('pending','opened'))::int as tasks_active,
+      count(*) filter (where pt.status = 'done')::int as tasks_done
+    from public.poll_tasks pt
+    where pt.owner_id = auth.uid()
+    group by pt.game_id
+  ),
+  recipients as (
+    select
+      pt.game_id,
+      (
+        array_agg(
+          coalesce(p.username, pt.recipient_email, '—')
+          order by pt.created_at desc
+        )
+        filter (where pt.status in ('pending','opened'))
+      )[1:6] as recipients_preview
+    from public.poll_tasks pt
+    left join public.profiles p on p.id = pt.recipient_user_id
+    where pt.owner_id = auth.uid()
+    group by pt.game_id
+  )
+  select
+    mp.id as game_id,
+    mp.name,
+    mp.type as poll_type,
+    mp.created_at,
+    case
+      when mp.status = 'poll_open' then 'open'
+      when mp.status = 'ready' then 'closed'
+      when coalesce(s.sessions_total, 0) > 0 then 'closed'
+      else 'draft'
+    end as poll_state,
+    coalesce(s.sessions_total, 0) as sessions_total,
+    coalesce(s.open_questions, 0) as open_questions,
+    coalesce(s.closed_questions, 0) as closed_questions,
+    coalesce(t.tasks_active, 0) as tasks_active,
+    coalesce(t.tasks_done, 0) as tasks_done,
+    coalesce(r.recipients_preview, array[]::text[]) as recipients_preview,
+    mp.share_key_poll,
+    case
+      when mp.status = 'poll_open' and coalesce(t.tasks_active,0) > 0 then 'mixed'
+      when coalesce(t.tasks_active,0) > 0 then 'subs'
+      else 'anon'
+    end as share_kind,
+    case
+      when mp.type = 'poll_points'::public.game_type then (
+        select count(*)::int
+        from public.poll_votes v
+        where v.game_id = mp.id and v.voter_user_id is null
+      )
+      else (
+        select count(*)::int
+        from public.poll_text_entries e
+        where e.game_id = mp.id and e.voter_user_id is null
+      )
+    end as anon_votes
+  from my_polls mp
+  left join sess s on s.game_id = mp.id
+  left join tasks t on t.game_id = mp.id
+  left join recipients r on r.game_id = mp.id
+  order by mp.created_at desc;
+end;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.poll_admin_delete_vote(p_game_id uuid, p_voter_token text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  u uuid;
+  deleted_points int := 0;
+  deleted_text int := 0;
+  task_id uuid;
+BEGIN
+  u := auth.uid();
+  IF u IS NULL THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'not_authenticated');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.games g
+    WHERE g.id = p_game_id AND g.owner_id = u
+  ) THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'not_owner');
+  END IF;
+
+  DELETE FROM public.poll_votes
+   WHERE game_id = p_game_id
+     AND voter_token = p_voter_token;
+  GET DIAGNOSTICS deleted_points = ROW_COUNT;
+
+  DELETE FROM public.poll_text_entries
+   WHERE game_id = p_game_id
+     AND voter_token = p_voter_token;
+  GET DIAGNOSTICS deleted_text = ROW_COUNT;
+
+  IF p_voter_token LIKE 'task:%' THEN
+    BEGIN
+      task_id := nullif(split_part(p_voter_token, ':', 2), '')::uuid;
+    EXCEPTION WHEN others THEN
+      task_id := null;
+    END;
+
+    IF task_id IS NOT NULL THEN
+      UPDATE public.poll_tasks
+        SET status = 'pending',
+            done_at = null,
+            opened_at = null,
+            declined_at = null,
+            cancelled_at = null
+      WHERE id = task_id AND owner_id = u;
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'deleted_poll_votes', deleted_points,
+    'deleted_poll_text_entries', deleted_text
+  );
+END;
+$function$;


### PR DESCRIPTION
### Motivation
- Make the Polls Hub UI consistent with other pages (Bases/builder), fix overflowing list rows and mobile tab labels, and improve toggle/button affordances.
- Prevent exporting an actively open poll from the builder and ensure the UI reflects exportability returned by the DB.
- Ensure deleting a vote properly resets a task created for that vote and make invitation handling smoother in the poll-go flow.

### Description
- Updated `polls-hub.html` to align the header with other pages, add a local `bar` heading, shorten some mobile tab labels and add a `btn-toggle` class to toggle buttons for consistent styling.
- Enhanced `css/polls-hub.css` to add list separators, ellipsis overflow handling for long rows, styled toggle buttons (`.btn-toggle`) and tuned mobile tabs layout and radii.
- Propagated navigation source via query string: `js/pages/polls-hub.js` now opens polls with `&from=polls-hub`, `js/pages/builder.js` opens with `&from=builder`, and `js/pages/polls.js` reads `from` to set the back destination and label.
- Made builder export control respect DB-calculated `can_export` by using `game_action_state` results in `js/pages/builder.js` (no longer forcing export to true on error); updated export UI flow accordingly.
- Improved `poll-go` behaviour by removing the extra `Dalej` button from `poll_go.html` and adding Enter-key handling in `js/pages/poll-go.js` to submit email input.
- Applied DB-side changes in `supabase/schema.sql` and added a migration `supabase/migrations/20250927140000_poll_hub_state_export.sql` to: mark `mp.status = 'ready'` as `closed` in `polls_hub_list_polls()`, block export when `g.status = 'poll_open'` in `game_action_state()`, and extend `poll_admin_delete_vote()` to reset `poll_tasks` (status/opened/done/declined/cancelled) when a vote linked to a task is deleted.

### Testing
- Launched a local static server with `python -m http.server` and captured a screenshot of `polls-hub.html` using a Playwright script to verify the header/tabs/list layout; the screenshot run completed successfully and produced an artifact.
- No automated unit tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698768fcc2c88321a78932496d3a091b)