### PR TITLE
Fix mobile poll hub item overflow and card rounding

### DIFF
--- a/css/polls-hub.css
+++ b/css/polls-hub.css
@@ -258,6 +258,16 @@ body.polls-hub-body {
   --radius: 12px;
 }
 
+.hub-tabs-mobile:has(#tabPollsMobile.active) .hub-card {
+  border-top-left-radius: 0;
+  border-top-right-radius: var(--radius);
+}
+
+.hub-tabs-mobile:has(#tabSubscriptionsMobile.active) .hub-card {
+  border-top-left-radius: var(--radius);
+  border-top-right-radius: 0;
+}
+
 .hub-tabs-mobile .tabs-strip {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -373,5 +383,26 @@ body.polls-hub-body {
 
   .hub-details {
     grid-template-columns: 1fr;
+  }
+
+  .hub-mobile .hub-item {
+    align-items: flex-start;
+    flex-wrap: wrap;
+    min-height: 64px;
+  }
+
+  .hub-mobile .hub-item > div:first-child {
+    width: 100%;
+  }
+
+  .hub-mobile .hub-item .hub-item-title,
+  .hub-mobile .hub-item .hub-item-sub {
+    white-space: normal;
+    word-break: break-word;
+  }
+
+  .hub-mobile .hub-item-actions {
+    width: 100%;
+    justify-content: flex-end;
   }
 }


### PR DESCRIPTION
### Motivation
- Mobile list entries in the polls hub could overflow horizontally causing titles/subtitles to escape the card, and the mobile tabs should remove the top corner rounding on the extreme selected tabs to match desktop behavior.

### Description
- Updated `css/polls-hub.css` to add mobile `:has()` rules so selected left/right mobile tabs remove the corresponding top corner radius on `.hub-card`.
- Made `.hub-mobile .hub-item` wrap and grow taller with `min-height: 64px` so long titles/subtitles no longer overflow horizontally.
- Ensured the first child of a mobile `.hub-item` takes full width and that `.hub-item-title`/`.hub-item-sub` use `white-space: normal` and `word-break: break-word` to allow wrapping.
- Set `.hub-mobile .hub-item-actions` to full-width and right-aligned to keep action buttons visually separated on wrapped items.

### Testing
- Ran a local dev server with `python -m http.server` and captured a mobile viewport screenshot using a Playwright script at `390x844`, which produced `artifacts/polls-hub-mobile.png` successfully.
- Committed the CSS change and verified the working tree reflects the update; no automated unit test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698770659dbc8321a91177ff784f0678)