### PR TITLE
Add username onboarding, account settings and account deletion flow

### DIFF
--- a/account.html
+++ b/account.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Familiada — ustawienia konta</title>
+
+  <link rel="icon" href="favicon.ico" />
+  <link rel="stylesheet" href="css/base.css"/>
+  <link rel="stylesheet" href="css/auth-landing.css"/>
+  <link rel="stylesheet" href="css/account.css"/>
+
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
+  <script type="module" src="js/pages/account.js" defer></script>
+</head>
+
+<body class="landing-body">
+  <div class="landing-shell">
+    <div class="landing-card account-card">
+      <div class="brand">FAMILIADA</div>
+      <div class="sub">Ustawienia konta</div>
+
+      <div class="status" id="status">Ładuję profil…</div>
+      <div class="err" id="err"></div>
+
+      <section class="section">
+        <div class="section-title">Nazwa użytkownika</div>
+        <input id="username" placeholder="Nazwa użytkownika" autocomplete="username"/>
+        <button class="btn main" id="saveUsername" type="button">Zapisz nazwę</button>
+      </section>
+
+      <section class="section">
+        <div class="section-title">E-mail</div>
+        <input id="email" type="email" placeholder="Nowy e-mail" autocomplete="email"/>
+        <button class="btn main" id="saveEmail" type="button">Zmień e-mail</button>
+        <div class="section-hint">Może być wymagana potwierdzająca wiadomość na nowy adres.</div>
+      </section>
+
+      <section class="section">
+        <div class="section-title">Hasło</div>
+        <input id="pass1" type="password" placeholder="Nowe hasło" autocomplete="new-password"/>
+        <input id="pass2" type="password" placeholder="Powtórz nowe hasło" autocomplete="new-password"/>
+        <button class="btn main" id="savePass" type="button">Zmień hasło</button>
+      </section>
+
+      <section class="section danger">
+        <div class="section-title">Usuń konto</div>
+        <div class="section-hint">Ta operacja jest nieodwracalna.</div>
+        <input id="deleteConfirm" placeholder="Wpisz USUŃ, aby potwierdzić" autocomplete="off"/>
+        <button class="btn danger" id="deleteAccount" type="button">Usuń konto i dane</button>
+      </section>
+
+      <div class="actions">
+        <a class="btn" href="builder.html">Wróć do panelu</a>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/builder.html
+++ b/builder.html
@@ -39,7 +39,10 @@
           <span class="only-mobile">🖥️</span>
       </button>
       
-      <span class="who" id="who">—</span>
+      <button class="btn user-btn" id="btnAccount" type="button">
+        <span class="user-name" id="who">—</span>
+        <span class="user-sub">Edytuj dane</span>
+      </button>
       <button class="btn sm" id="btnLogout" type="button">Wyloguj</button>
     </div>
   </header>

--- a/css/account.css
+++ b/css/account.css
@@ -1,0 +1,34 @@
+.account-card {
+  display: grid;
+  gap: 16px;
+}
+
+.section {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border-radius: 16px;
+  border: 1px solid rgba(255,255,255,.12);
+  background: rgba(0,0,0,.18);
+}
+
+.section-title {
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: .08em;
+}
+
+.section-hint {
+  font-size: 12px;
+  opacity: .75;
+}
+
+.section.danger {
+  border-color: rgba(255,120,120,.35);
+  background: rgba(255,120,120,.08);
+}
+
+.section .btn {
+  justify-self: start;
+}

--- a/css/base.css
+++ b/css/base.css
@@ -57,6 +57,29 @@ body {
     font-size: 13px
 }
 
+.user-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    min-width: 140px;
+    text-align: left;
+    line-height: 1.1
+}
+
+.user-btn .user-name {
+    font-size: 13px;
+    font-weight: 900;
+    opacity: .95
+}
+
+.user-btn .user-sub {
+    font-size: 11px;
+    opacity: .7;
+    text-transform: none;
+    letter-spacing: .02em
+}
+
 .btn {
     padding: 10px 12px;
     border-radius: 14px;

--- a/css/login.css
+++ b/css/login.css
@@ -112,3 +112,55 @@ input:focus {
     color: #ff9d9d;
     font-size: 12px
 }
+
+.overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(5,9,20,.72);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 18px;
+    z-index: 20
+}
+
+.overlay.is-open {
+    display: flex
+}
+
+.modal {
+    width: min(460px,90vw);
+    background: rgba(255,255,255,.08);
+    border: 1px solid rgba(255,255,255,.18);
+    border-radius: 18px;
+    padding: 18px;
+    box-shadow: 0 24px 60px rgba(0,0,0,.6)
+}
+
+.modal-title {
+    font-weight: 900;
+    letter-spacing: .06em;
+    text-transform: uppercase;
+    font-size: 14px
+}
+
+.modal-sub {
+    opacity: .8;
+    margin-top: 6px;
+    margin-bottom: 12px;
+    font-size: 13px
+}
+
+.modal-actions {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin-top: 12px
+}
+
+.modal-err {
+    color: #ff9d9d;
+    font-size: 12px;
+    min-height: 16px;
+    margin-top: 6px
+}

--- a/index.html
+++ b/index.html
@@ -23,7 +23,6 @@
 
       <div class="form">
         <input id="email" type="email" placeholder="Email" autocomplete="email"/>
-        <input id="username" placeholder="Nazwa użytkownika" autocomplete="username" />
         <input id="pass" type="password" placeholder="Hasło" autocomplete="current-password"/>
         <input id="pass2" type="password" placeholder="Powtórz hasło" autocomplete="new-password" style="display:none"/>
 
@@ -39,6 +38,19 @@
       </div>
     </div>
   </div>
+
+  <div class="overlay" id="usernameOverlay" aria-hidden="true">
+    <div class="modal">
+      <div class="modal-title">Ustaw nazwę użytkownika</div>
+      <div class="modal-sub">To jednorazowe ustawienie pomoże Cię rozpoznać w panelu.</div>
+
+      <input id="usernameFirst" placeholder="Nazwa użytkownika" autocomplete="username" />
+      <div class="modal-err" id="usernameErr"></div>
+
+      <div class="modal-actions">
+        <button class="btn main" id="btnUsernameSave" type="button">Zapisz</button>
+      </div>
+    </div>
+  </div>
 </body>
 </html>
-

--- a/js/pages/account.js
+++ b/js/pages/account.js
@@ -1,0 +1,120 @@
+import { sb } from "../core/supabase.js";
+import { requireAuth, validateUsername, signOut } from "../core/auth.js";
+
+const status = document.getElementById("status");
+const err = document.getElementById("err");
+
+const usernameInput = document.getElementById("username");
+const emailInput = document.getElementById("email");
+const pass1 = document.getElementById("pass1");
+const pass2 = document.getElementById("pass2");
+const deleteConfirm = document.getElementById("deleteConfirm");
+
+const saveUsername = document.getElementById("saveUsername");
+const saveEmail = document.getElementById("saveEmail");
+const savePass = document.getElementById("savePass");
+const deleteAccount = document.getElementById("deleteAccount");
+
+function setStatus(m = "") { if (status) status.textContent = m; }
+function setErr(m = "") { if (err) err.textContent = m; }
+
+async function loadProfile() {
+  const user = await requireAuth("index.html?setup=username");
+  if (!user) return;
+  usernameInput.value = user.username || "";
+  emailInput.value = user.email || "";
+  setStatus("Profil załadowany.");
+}
+
+async function handleUsernameSave() {
+  setErr("");
+  try {
+    const username = validateUsername(usernameInput.value || "");
+    const { data: userData, error: userError } = await sb().auth.getUser();
+    if (userError || !userData?.user) throw new Error("Brak aktywnej sesji.");
+
+    const { error } = await sb()
+      .from("profiles")
+      .update({ username })
+      .eq("id", userData.user.id);
+    if (error) throw error;
+
+    await sb().auth.updateUser({ data: { username } });
+    setStatus("Nazwa użytkownika zapisana.");
+  } catch (e) {
+    console.error(e);
+    setErr(e?.message || String(e));
+  }
+}
+
+async function handleEmailSave() {
+  setErr("");
+  try {
+    const mail = String(emailInput.value || "").trim().toLowerCase();
+    if (!mail || !mail.includes("@")) throw new Error("Podaj poprawny e-mail.");
+
+    const { data, error } = await sb().auth.updateUser({ email: mail });
+    if (error) throw error;
+
+    if (data?.user?.email?.toLowerCase() === mail) {
+      const { error: profileError } = await sb()
+        .from("profiles")
+        .update({ email: mail })
+        .eq("id", data.user.id);
+      if (profileError) throw profileError;
+    }
+
+    setStatus("Zapisano zmianę e-maila. Sprawdź skrzynkę.");
+  } catch (e) {
+    console.error(e);
+    setErr(e?.message || String(e));
+  }
+}
+
+async function handlePassSave() {
+  setErr("");
+  try {
+    const a = String(pass1.value || "");
+    const b = String(pass2.value || "");
+    if (a.length < 6) throw new Error("Hasło musi mieć co najmniej 6 znaków.");
+    if (a !== b) throw new Error("Hasła nie są takie same.");
+
+    const { error } = await sb().auth.updateUser({ password: a });
+    if (error) throw error;
+
+    pass1.value = "";
+    pass2.value = "";
+    setStatus("Hasło zostało zmienione.");
+  } catch (e) {
+    console.error(e);
+    setErr(e?.message || String(e));
+  }
+}
+
+async function handleDeleteAccount() {
+  setErr("");
+  try {
+    const confirm = String(deleteConfirm.value || "").trim().toUpperCase();
+    if (confirm !== "USUŃ") throw new Error("Wpisz USUŃ, aby potwierdzić.");
+
+    setStatus("Usuwam konto…");
+    const { data, error } = await sb().functions.invoke("delete-account");
+    if (error) throw error;
+    if (!data?.ok) throw new Error(data?.error || "Nie udało się usunąć konta.");
+
+    await signOut();
+    location.href = "index.html";
+  } catch (e) {
+    console.error(e);
+    setStatus("Błąd.");
+    setErr(e?.message || String(e));
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  loadProfile();
+  saveUsername?.addEventListener("click", handleUsernameSave);
+  saveEmail?.addEventListener("click", handleEmailSave);
+  savePass?.addEventListener("click", handlePassSave);
+  deleteAccount?.addEventListener("click", handleDeleteAccount);
+});

--- a/js/pages/builder.js
+++ b/js/pages/builder.js
@@ -21,6 +21,7 @@ const grid = document.getElementById("grid");
 const who = document.getElementById("who");
 const hint = document.getElementById("hint");
 
+const btnAccount = document.getElementById("btnAccount");
 const btnLogout = document.getElementById("btnLogout");
 const btnEdit = document.getElementById("btnEdit");
 const btnPlay = document.getElementById("btnPlay");
@@ -739,6 +740,10 @@ document.addEventListener("DOMContentLoaded", async () => {
   btnLogout?.addEventListener("click", async () => {
     await signOut();
     location.href = "index.html";
+  });
+
+  btnAccount?.addEventListener("click", () => {
+    location.href = "account.html";
   });
 
   btnManual?.addEventListener("click", async () => {

--- a/js/pages/confirm.js
+++ b/js/pages/confirm.js
@@ -40,30 +40,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (error) throw error;
 
     if (data?.session) {
-      // zapisz profil (username z user_metadata)
-      try {
-        const u = data.user;
-        const mail = String(u?.email || "").toLowerCase();
-        const un = String(u?.user_metadata?.username || "").trim();
-
-        if (!un) {
-          // powinno być zawsze, bo rejestracja wymaga username
-          throw new Error("Brak nazwy użytkownika w profilu rejestracji.");
-        }
-
-        // zakładam: profiles.id = auth.users.id
-        const { error: e2 } = await sb()
-          .from("profiles")
-          .upsert({ id: u.id, email: mail, username: un }, { onConflict: "id" });
-
-        if (e2) throw e2;
-      } catch (e) {
-        console.error(e);
-        setStatus("Konto potwierdzone, ale nie mogę zapisać profilu.");
-        setErr(e?.message || String(e));
-        back.style.display = "inline-flex";
-        return;
-      }
       setStatus("Gotowe! Konto potwierdzone.");
       go.style.display = "inline-flex";
       setTimeout(() => (location.href = "builder.html"), 700);

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,0 +1,72 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY")!;
+const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+
+const sb = createClient(supabaseUrl, supabaseAnonKey);
+const admin = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { persistSession: false, autoRefreshToken: false },
+});
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  if (req.method !== "POST") {
+    return json({ ok: false, error: "Method not allowed" }, 405);
+  }
+
+  try {
+    if (!serviceRoleKey) {
+      return json({ ok: false, error: "Missing SUPABASE_SERVICE_ROLE_KEY" }, 500);
+    }
+    const authHeader = req.headers.get("authorization") || "";
+    const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+    if (!token) return json({ ok: false, error: "Missing Bearer token" }, 401);
+
+    const { data: userData, error: authError } = await sb.auth.getUser(token);
+    if (authError || !userData?.user) {
+      return json({ ok: false, error: "Invalid JWT" }, 401);
+    }
+
+    const userId = userData.user.id;
+
+    const deletions = [
+      admin.from("poll_text_entries").delete().eq("voter_user_id", userId),
+      admin.from("poll_votes").delete().eq("voter_user_id", userId),
+      admin.from("poll_subscriptions").delete().eq("subscriber_user_id", userId),
+      admin.from("poll_tasks").delete().eq("recipient_user_id", userId),
+    ];
+
+    for (const req of deletions) {
+      const { error } = await req;
+      if (error) throw error;
+    }
+
+    const { error: profileError } = await admin.from("profiles").delete().eq("id", userId);
+    if (profileError) throw profileError;
+
+    const { error: deleteError } = await admin.auth.admin.deleteUser(userId);
+    if (deleteError) throw deleteError;
+
+    return json({ ok: true });
+  } catch (e) {
+    return json({ ok: false, error: String(e?.message || e) }, 500);
+  }
+});
+
+function json(obj: unknown, status = 200) {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}

--- a/supabase/migrations/20251003100000_profiles_username_optional.sql
+++ b/supabase/migrations/20251003100000_profiles_username_optional.sql
@@ -1,0 +1,52 @@
+begin;
+
+alter table public.profiles
+  alter column username drop not null;
+
+drop trigger if exists trg_profiles_username_immutable on public.profiles;
+drop function if exists public.profiles_username_immutable();
+
+create or replace function public.handle_new_user()
+ returns trigger
+ language plpgsql
+ security definer
+ set search_path to 'public'
+as $function$
+declare
+  v_email text;
+  v_username text;
+begin
+  v_email := lower(coalesce(new.email, ''));
+
+  v_username := trim(coalesce(new.raw_user_meta_data->>'username', ''));
+  if v_username = '' then
+    v_username := null;
+  end if;
+
+  insert into public.profiles (id, email, username)
+  values (new.id, v_email, v_username)
+  on conflict (id) do update
+    set email = excluded.email,
+        username = excluded.username;
+
+  return new;
+end;
+$function$;
+
+drop policy if exists profiles_select_authenticated on public.profiles;
+drop policy if exists profiles_update_self on public.profiles;
+
+create policy profiles_select_authenticated
+  on public.profiles
+  for select
+  to authenticated
+  using (true);
+
+create policy profiles_update_self
+  on public.profiles
+  for update
+  to authenticated
+  using (id = auth.uid())
+  with check (id = auth.uid());
+
+commit;


### PR DESCRIPTION
### Motivation
- Allow users to register without entering a username up-front and prompt them on first login to set a username so onboarding is less frictiony.
- Provide a proper account settings UI where users can edit username, email, password and delete their account with all related data cleaned up.
- Make the DB and server-side pieces consistent with optional usernames and ensure profile policies allow safe select/update by authenticated users.

### Description
- UI: removed the inline username field from the signup form and added a first-login modal (`index.html`, `css/login.css`, `js/pages/index.js`) that forces users without a username to set one before entering the builder.
- Account page: added `account.html`, `css/account.css` and `js/pages/account.js` to let users edit username, email, password and request account deletion; added a two-line account button to the topbar (`builder.html`, `css/base.css`, `js/pages/builder.js`) which links to the account page.
- Auth changes: updated `js/core/auth.js` so `signUp` no longer requires a username (accepts empty), exposed `validateUsername` with an `allowEmpty` option, and `requireAuth` redirects users missing username to the username setup flow.
- DB/migrations: added migration `supabase/migrations/20251003100000_profiles_username_optional.sql` and updated `supabase/schema.sql` to make `profiles.username` nullable, removed the immutable-username trigger/function, adjusted `handle_new_user` to insert nullable username, and added `profiles_select_authenticated` and `profiles_update_self` RLS policies.
- Delete-account function: added an Edge function `supabase/functions/delete-account/index.ts` that validates the caller, deletes profile-related rows (`poll_text_entries`, `poll_votes`, `poll_subscriptions`, `poll_tasks`, `profiles`) using the service role client and then removes the Auth user with `admin.auth.admin.deleteUser()`.
- Confirmation path: simplified `js/pages/confirm.js` to avoid forcing an initial username upsert during email confirmation (first-login modal handles that now).

### Testing
- Basic smoke UI check: started a local static server with `python -m http.server 8000` and ran a Playwright script to open `builder.html` and capture a screenshot which completed successfully; the screenshot artifact was produced.
- No automated unit tests were added or run for serverless function or DB migration in this change (manual deployment and DB migration required for full end-to-end verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987729e0f348321b7b7561b5121a30e)