### PR TITLE
Fix email-change redirect/confirm handling, require password for deletion, and subscription invite UI/behavior

### DIFF
--- a/account.html
+++ b/account.html
@@ -7,53 +7,65 @@
 
   <link rel="icon" href="favicon.ico" />
   <link rel="stylesheet" href="css/base.css"/>
-  <link rel="stylesheet" href="css/auth-landing.css"/>
+  <link rel="stylesheet" href="css/builder.css"/>
   <link rel="stylesheet" href="css/account.css"/>
 
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
   <script type="module" src="js/pages/account.js" defer></script>
 </head>
 
-<body class="landing-body">
-  <div class="landing-shell">
-    <div class="landing-card account-card">
-      <div class="brand">FAMILIADA</div>
-      <div class="sub">Ustawienia konta</div>
+<body class="account-body">
+  <header class="topbar">
+    <div class="brand">FAMILIADA</div>
+    <div class="right">
+      <a class="btn sm" href="builder.html">← Wróć do panelu</a>
+    </div>
+  </header>
 
-      <div class="status" id="status">Ładuję profil…</div>
-      <div class="err" id="err"></div>
-
-      <section class="section">
-        <div class="section-title">Nazwa użytkownika</div>
-        <input id="username" placeholder="Nazwa użytkownika" autocomplete="username"/>
-        <button class="btn main" id="saveUsername" type="button">Zapisz nazwę</button>
-      </section>
-
-      <section class="section">
-        <div class="section-title">E-mail</div>
-        <input id="email" type="email" placeholder="Nowy e-mail" autocomplete="email"/>
-        <button class="btn main" id="saveEmail" type="button">Zmień e-mail</button>
-        <div class="section-hint">Może być wymagana potwierdzająca wiadomość na nowy adres.</div>
-      </section>
-
-      <section class="section">
-        <div class="section-title">Hasło</div>
-        <input id="pass1" type="password" placeholder="Nowe hasło" autocomplete="new-password"/>
-        <input id="pass2" type="password" placeholder="Powtórz nowe hasło" autocomplete="new-password"/>
-        <button class="btn main" id="savePass" type="button">Zmień hasło</button>
-      </section>
-
-      <section class="section danger">
-        <div class="section-title">Usuń konto</div>
-        <div class="section-hint">Ta operacja jest nieodwracalna.</div>
-        <input id="deleteConfirm" placeholder="Wpisz USUŃ, aby potwierdzić" autocomplete="off"/>
-        <button class="btn danger" id="deleteAccount" type="button">Usuń konto i dane</button>
-      </section>
-
-      <div class="actions">
-        <a class="btn" href="builder.html">Wróć do panelu</a>
+  <main class="wrap account-wrap">
+    <div class="bar">
+      <div>
+        <div class="title">Ustawienia konta</div>
+        <div class="hint">Zarządzaj profilem, e-mailem i bezpieczeństwem.</div>
       </div>
     </div>
-  </div>
+
+    <div class="account-status">
+      <div class="status" id="status">Ładuję profil…</div>
+      <div class="err" id="err"></div>
+    </div>
+
+    <div class="account-grid">
+      <section class="account-panel">
+        <div class="section-title">Nazwa użytkownika</div>
+        <div class="section-hint">Widoczna dla subskrybentów i w panelu.</div>
+        <input class="inp" id="username" placeholder="Nazwa użytkownika" autocomplete="username"/>
+        <button class="btn gold full" id="saveUsername" type="button">Zapisz nazwę</button>
+      </section>
+
+      <section class="account-panel">
+        <div class="section-title">E-mail</div>
+        <div class="section-hint">Zmieniaj adres logowania.</div>
+        <input class="inp" id="email" type="email" placeholder="Nowy e-mail" autocomplete="email"/>
+        <button class="btn gold full" id="saveEmail" type="button">Zmień e-mail</button>
+        <div class="section-hint">Po zmianie nastąpi wylogowanie i wymagane będzie ponowne logowanie.</div>
+      </section>
+
+      <section class="account-panel">
+        <div class="section-title">Hasło</div>
+        <div class="section-hint">Minimum 6 znaków.</div>
+        <input class="inp" id="pass1" type="password" placeholder="Nowe hasło" autocomplete="new-password"/>
+        <input class="inp" id="pass2" type="password" placeholder="Powtórz nowe hasło" autocomplete="new-password"/>
+        <button class="btn gold full" id="savePass" type="button">Zmień hasło</button>
+      </section>
+
+      <section class="account-panel danger">
+        <div class="section-title">Usuń konto</div>
+        <div class="section-hint">Ta operacja jest nieodwracalna. Wpisz hasło, aby potwierdzić.</div>
+        <input class="inp" id="deletePassword" type="password" placeholder="Hasło" autocomplete="current-password"/>
+        <button class="btn danger full" id="deleteAccount" type="button">Usuń konto i dane</button>
+      </section>
+    </div>
+  </main>
 </body>
 </html>

--- a/css/account.css
+++ b/css/account.css
@@ -1,34 +1,74 @@
-.account-card {
+.account-body {
+  min-height: 100vh;
+  background: var(--bg);
+  color: #fff;
+}
+
+.account-wrap {
+  padding-bottom: 28px;
+}
+
+.account-status {
+  margin-top: 10px;
+  display: grid;
+  gap: 8px;
+}
+
+.account-status .status {
+  padding: 12px 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(255,234,166,.2);
+  background: rgba(0,0,0,.22);
+}
+
+.account-status .err {
+  min-height: 18px;
+  color: #ff9d9d;
+  font-size: 13px;
+}
+
+.account-grid {
+  margin-top: 16px;
   display: grid;
   gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.section {
+.account-panel {
   display: grid;
   gap: 10px;
-  padding: 12px;
-  border-radius: 16px;
+  padding: 16px;
+  border-radius: 18px;
   border: 1px solid rgba(255,255,255,.12);
-  background: rgba(0,0,0,.18);
+  background: rgba(0,0,0,.24);
+  box-shadow: 0 18px 40px rgba(0,0,0,.35);
 }
 
-.section-title {
+.account-panel .section-title {
   font-weight: 900;
   text-transform: uppercase;
   font-size: 12px;
   letter-spacing: .08em;
 }
 
-.section-hint {
+.account-panel .section-hint {
   font-size: 12px;
   opacity: .75;
 }
 
-.section.danger {
+.account-panel.danger {
   border-color: rgba(255,120,120,.35);
   background: rgba(255,120,120,.08);
 }
 
-.section .btn {
-  justify-self: start;
+@media (max-width: 900px) {
+  .account-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .account-panel .btn {
+    width: 100%;
+  }
 }

--- a/css/login.css
+++ b/css/login.css
@@ -113,54 +113,41 @@ input:focus {
     font-size: 12px
 }
 
-.overlay {
-    position: fixed;
-    inset: 0;
-    background: rgba(5,9,20,.72);
-    display: none;
-    align-items: center;
-    justify-content: center;
-    padding: 18px;
-    z-index: 20
+.setup-card {
+    background: rgba(8,12,28,.6);
+    border: 1px solid rgba(255,234,166,.25);
+    box-shadow: 0 30px 80px rgba(0,0,0,.6)
 }
 
-.overlay.is-open {
-    display: flex
-}
-
-.modal {
-    width: min(460px,90vw);
-    background: rgba(255,255,255,.08);
-    border: 1px solid rgba(255,255,255,.18);
-    border-radius: 18px;
-    padding: 18px;
-    box-shadow: 0 24px 60px rgba(0,0,0,.6)
-}
-
-.modal-title {
+.setup-title {
+    margin-top: 10px;
     font-weight: 900;
-    letter-spacing: .06em;
+    letter-spacing: .08em;
     text-transform: uppercase;
     font-size: 14px
 }
 
-.modal-sub {
-    opacity: .8;
+.setup-sub {
     margin-top: 6px;
     margin-bottom: 12px;
-    font-size: 13px
+    font-size: 13px;
+    opacity: .8
+}
+
+.setup-form {
+    display: grid;
+    gap: 10px
 }
 
 .modal-actions {
     display: flex;
     gap: 10px;
     flex-wrap: wrap;
-    margin-top: 12px
+    margin-top: 4px
 }
 
 .modal-err {
     color: #ff9d9d;
     font-size: 12px;
-    min-height: 16px;
-    margin-top: 6px
+    min-height: 16px
 }

--- a/css/polls-hub.css
+++ b/css/polls-hub.css
@@ -111,11 +111,11 @@ body.polls-hub-body {
   display: grid;
   gap: 10px;
   min-height: 80px;
-}
-
-.hub-desktop .hub-list {
-  border-top: 1px solid rgba(255,255,255,.08);
-  padding-top: 10px;
+  padding: 12px;
+  border-radius: 16px;
+  border: 1px solid rgba(255,255,255,.12);
+  background: rgba(0,0,0,.2);
+  overflow: hidden;
 }
 
 .hub-item {
@@ -330,11 +330,20 @@ body.polls-hub-body {
   opacity: .8;
 }
 
-.hub-details {
+.hub-details-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr 180px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 14px;
   margin-top: 14px;
+}
+
+.hub-details-side {
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,.12);
+  background: rgba(255,255,255,.04);
+  width: fit-content;
 }
 
 .hub-details-head {
@@ -381,7 +390,7 @@ body.polls-hub-body {
     grid-template-columns: 1fr;
   }
 
-  .hub-details {
+  .hub-details-grid {
     grid-template-columns: 1fr;
   }
 

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 </head>
 <body class="login-body">
   <div class="login-shell">
-    <div class="login-card">
+    <div class="login-card" id="loginCard">
       <div class="brand">FAMILIADA</div>
       <div class="sub">Panel tworzenia i prowadzenia gry</div>
 
@@ -37,18 +37,19 @@
         </div>
       </div>
     </div>
-  </div>
 
-  <div class="overlay" id="usernameOverlay" aria-hidden="true">
-    <div class="modal">
-      <div class="modal-title">Ustaw nazwę użytkownika</div>
-      <div class="modal-sub">To jednorazowe ustawienie pomoże Cię rozpoznać w panelu.</div>
+    <div class="login-card setup-card" id="setupCard" hidden>
+      <div class="brand">FAMILIADA</div>
+      <div class="sub">Pierwsze logowanie</div>
+      <div class="setup-title">Ustaw nazwę użytkownika</div>
+      <div class="setup-sub">Będzie widoczna w panelu oraz przy zaproszeniach.</div>
 
-      <input id="usernameFirst" placeholder="Nazwa użytkownika" autocomplete="username" />
-      <div class="modal-err" id="usernameErr"></div>
-
-      <div class="modal-actions">
-        <button class="btn main" id="btnUsernameSave" type="button">Zapisz</button>
+      <div class="setup-form">
+        <input id="usernameFirst" placeholder="Nazwa użytkownika" autocomplete="username" />
+        <div class="modal-err" id="usernameErr"></div>
+        <div class="modal-actions">
+          <button class="btn main" id="btnUsernameSave" type="button">Zapisz nazwę</button>
+        </div>
       </div>
     </div>
   </div>

--- a/js/pages/confirm.js
+++ b/js/pages/confirm.js
@@ -12,6 +12,10 @@ function qp(name){
   return new URL(location.href).searchParams.get(name);
 }
 
+function hp(name){
+  return new URLSearchParams(location.hash.replace(/^#/, "")).get(name);
+}
+
 document.addEventListener("DOMContentLoaded", async () => {
   setErr("");
 
@@ -26,7 +30,15 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   } catch {}
 
-  const code = qp("code");
+  const hashError = hp("error_description") || hp("error");
+  if (hashError) {
+    setStatus("Link jest nieprawidłowy lub wygasł.");
+    setErr(decodeURIComponent(hashError.replace(/\+/g, " ")));
+    back.style.display = "inline-flex";
+    return;
+  }
+
+  const code = qp("code") || hp("code");
   if (!code) {
     setStatus("Brak kodu w linku.");
     setErr("Wygląda na to, że link jest niepełny albo został już użyty.");

--- a/polls-hub.html
+++ b/polls-hub.html
@@ -138,10 +138,6 @@
                   </div>
                   <div class="hub-controls">
                     <select class="inp sm" id="sortSubscriptionsDesktop"></select>
-                    <div class="hub-toggle" data-kind="subscriptions">
-                      <button class="btn xs btn-toggle" data-toggle="current">Aktualne</button>
-                      <button class="btn xs btn-toggle" data-toggle="archive">Archiwalne</button>
-                    </div>
                   </div>
                 </div>
                 <div class="hub-list" id="subscriptionsListDesktop"></div>
@@ -267,10 +263,6 @@
               </div>
               <div class="hub-controls">
                 <select class="inp sm" id="sortSubscriptionsMobile"></select>
-                <div class="hub-toggle" data-kind="subscriptions">
-                  <button class="btn xs btn-toggle" data-toggle="current">Aktualne</button>
-                  <button class="btn xs btn-toggle" data-toggle="archive">Archiwalne</button>
-                </div>
               </div>
             </div>
             <div class="hub-list" id="subscriptionsListMobile"></div>
@@ -297,19 +289,27 @@
     <div class="modal">
       <div class="mTitle" id="detailsTitle">Szczegóły głosowania</div>
       <div class="mSub">Usuń głos powiązany z zadaniem, jeśli to konieczne.</div>
-      <div class="hub-details">
+      <div class="hub-details-grid">
         <div>
           <div class="hub-details-head">Zagłosowali</div>
           <div class="hub-details-list" id="detailsVoted"></div>
         </div>
         <div>
-          <div class="hub-details-head">Nie zagłosowali / Odrzucili</div>
+          <div class="hub-details-head">Nie zagłosowali</div>
           <div class="hub-details-list" id="detailsPending"></div>
         </div>
-        <div class="hub-details-side">
-          <div class="hub-details-head">Anonimowe</div>
-          <div class="hub-anon-count" id="detailsAnon">0</div>
+        <div>
+          <div class="hub-details-head">Odrzucili</div>
+          <div class="hub-details-list" id="detailsDeclined"></div>
         </div>
+        <div>
+          <div class="hub-details-head">Anulowane</div>
+          <div class="hub-details-list" id="detailsCancelled"></div>
+        </div>
+      </div>
+      <div class="hub-details-side">
+        <div class="hub-details-head">Anonimowe</div>
+        <div class="hub-anon-count" id="detailsAnon">0</div>
       </div>
       <div class="hub-modal-actions">
         <button class="btn sm" id="btnDetailsClose" type="button">Zamknij</button>

--- a/supabase/migrations/20251004120000_fix_subscription_invite.sql
+++ b/supabase/migrations/20251004120000_fix_subscription_invite.sql
@@ -1,0 +1,82 @@
+create or replace function public.polls_hub_subscription_invite(p_recipient text)
+ returns jsonb
+ language plpgsql
+ security definer
+ set search_path to 'public', 'pg_temp'
+as $function$
+declare
+  v_rec text := lower(trim(coalesce(p_recipient,'')));
+  v_user_id uuid;
+  v_email text;
+  v_token uuid;
+  v_id uuid;
+begin
+  if v_rec = '' then
+    return jsonb_build_object('ok', false, 'error', 'empty recipient');
+  end if;
+
+  -- 1) spróbuj po username
+  select id, email into v_user_id, v_email
+  from public.profiles
+  where lower(username) = v_rec
+  limit 1;
+
+  -- 2) jeśli nie znaleziono po username, spróbuj po email
+  if v_user_id is null then
+    select id, email into v_user_id, v_email
+    from public.profiles
+    where lower(email) = v_rec
+    limit 1;
+  end if;
+
+  -- docelowy email do rekordu (z profilu albo wpisany)
+  if v_email is null then
+    v_email := v_rec;
+  end if;
+
+  -- jeśli już istnieje pending/active do tego odbiorcy (po user_id lub email), nie twórz duplikatu
+  select ps.id, ps.token into v_id, v_token
+  from public.poll_subscriptions ps
+  where ps.owner_id = auth.uid()
+    and (
+      (v_user_id is not null and ps.subscriber_user_id = v_user_id)
+      or (ps.subscriber_email is not null and lower(ps.subscriber_email) = v_email)
+    )
+    and ps.status in ('pending','active')
+  limit 1;
+
+  if v_id is not null then
+    return jsonb_build_object(
+      'ok', true,
+      'already', true,
+      'id', v_id,
+      'token', v_token,
+      'channel', case when v_user_id is not null then 'onsite' else 'email' end
+    );
+  end if;
+
+  -- wstaw invite/subscription
+  insert into public.poll_subscriptions (
+    owner_id,
+    subscriber_user_id,
+    subscriber_email,
+    status
+  )
+  values (
+    auth.uid(),
+    v_user_id,
+    case when v_user_id is null then v_email else null end,
+    'pending'
+  )
+  returning id, token into v_id, v_token;
+
+  return jsonb_build_object(
+    'ok', true,
+    'already', false,
+    'id', v_id,
+    'token', v_token,
+    'channel', case when v_user_id is not null then 'onsite' else 'email' end,
+    'email', case when v_user_id is null then v_email else null end
+  );
+end;
+$function$;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -4353,7 +4353,7 @@ begin
   values (
     auth.uid(),
     v_user_id,
-    v_email,
+    case when v_user_id is null then v_email else null end,
     'pending'
   )
   returning id, token into v_id, v_token;
@@ -4364,7 +4364,7 @@ begin
     'id', v_id,
     'token', v_token,
     'channel', case when v_user_id is not null then 'onsite' else 'email' end,
-    'email', v_email
+    'email', case when v_user_id is null then v_email else null end
   );
 end;
 $function$


### PR DESCRIPTION
### Motivation
- Ensure Supabase email-change links redirect to a page that can parse the code or error hash instead of landing at `/` where the error is not presented to the user. 
- Improve account-deletion safety by requiring the user to re-authenticate with a password before invoking the server-side delete flow. 
- Make subscription/invite behavior consistent and surface richer invite/detail states in the UI.

### Description
- Make email updates request an explicit redirect to `confirm.html` by passing `emailRedirectTo` to `sb().auth.updateUser` in `js/pages/account.js`. 
- Parse and surface hash-based OAuth errors (`#error`, `#error_description`) and accept `code` from either query or hash in `js/pages/confirm.js`. 
- Require the current password for account deletion by re-authenticating with `sb().auth.signInWithPassword` before invoking the `delete-account` function and replace the simple text-confirm UI with a password field in `account.html` and `css/account.css`. 
- Persist a `pendingEmailChange` object to `localStorage` on email change and block logins using the old address in `js/pages/index.js`, clearing the flag on successful login. 
- Add username-availability checks (`ensureUsernameAvailable`) in both `js/pages/account.js` and `js/pages/index.js` before saving usernames. 
- Adjust subscription invite behavior server-side with a new/updated function (`supabase/migrations/20251004120000_fix_subscription_invite.sql`) so `poll_subscriptions.subscriber_email` is only stored for external invites and the RPC returns `channel`; send/resend email invites only when `channel === 'email'` in `js/pages/polls-hub.js`. 
- Expand the polls hub details UI to show `declined` and `cancelled` lists and update layout and styling across `account.html`, `index.html`, `polls-hub.html`, and several CSS files to match the new composition.

### Testing
- No automated tests or CI jobs were executed for these changes. 
- Only code-level sanity checks and commits were made locally; automated UI or integration tests were not run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69877ddefd108321bc209c203646fb02)