### PR TITLE
Sync device language from control and localize host swipe hints

### DIFF
--- a/control/js/app.js
+++ b/control/js/app.js
@@ -1,5 +1,5 @@
 // /familiada/js/pages/control/app.js
-import { initI18n, t } from "../../translation/translation.js";
+import { getUiLang, initI18n, t } from "../../translation/translation.js";
 
 // ================== KOMUNIKATY ==================
 const APP_MSG = {
@@ -726,6 +726,12 @@ async function sendZeroStatesToDevices() {
   }
 
   devices.initLinksAndQr();
+  const initialLang = getUiLang();
+  devices.updateLinksAndQr(initialLang);
+  await devices.sendDisplayCmd(`LANG ${initialLang}`);
+  await devices.sendHostCmd(`LANG ${initialLang}`);
+  await devices.sendBuzzerCmd(`LANG ${initialLang}`);
+  await devices.sendQrToDisplay();
   window.addEventListener("i18n:lang", async (event) => {
     const nextLang = event?.detail?.lang;
     devices.updateLinksAndQr(nextLang);

--- a/js/pages/host.js
+++ b/js/pages/host.js
@@ -1,5 +1,5 @@
 // /familiada/js/pages/host.js
-import { initI18n, setUiLang } from "../../translation/translation.js";
+import { initI18n, setUiLang, t } from "../../translation/translation.js";
 import { sb } from "../core/supabase.js";
 
 /* ========= PARAMS ========= */
@@ -7,7 +7,7 @@ const qs = new URLSearchParams(location.search);
 const gameId = qs.get("id");
 const key = qs.get("key");
 
-initI18n({ withSwitcher: true });
+initI18n({ withSwitcher: false });
 
 /* ========= DOM ========= */
 const paperText1 = document.getElementById("paperText1");
@@ -22,6 +22,10 @@ const fsIco = document.getElementById("fsIco");
 // sekcje (nie zmieniamy HTML — bierzemy po klasach)
 const pane1 = document.querySelector(".pane1");
 const pane2 = document.querySelector(".pane2");
+
+window.addEventListener("i18n:lang", () => {
+  updateSwipeHint();
+});
 
 /* ========= DEVICE ID (presence) ========= */
 const DEVICE_ID_KEY = "familiada:deviceId:host";
@@ -343,14 +347,13 @@ function updateSwipeHint() {
 
   const onCover =
     o === "portrait"
-      ? (p2Covered ? "Przesuń w dół, żeby odsłonić" : "Przesuń w górę, żeby zasłonić")
-      : (p2Covered ? "Przesuń w prawo, żeby odsłonić" : "Przesuń w lewo, żeby zasłonić");
+      ? (p2Covered ? t("host.swipeRevealDown") : t("host.swipeCoverUp"))
+      : (p2Covered ? t("host.swipeRevealRight") : t("host.swipeCoverLeft"));
 
   if (cover2Swipe) cover2Swipe.textContent = onCover;
 
   if (p2Hint) {
-    p2Hint.textContent =
-      o === "portrait" ? "Przesuń w górę, żeby zasłonić" : "Przesuń w lewo, żeby zasłonić";
+    p2Hint.textContent = o === "portrait" ? t("host.swipeCoverUp") : t("host.swipeCoverLeft");
   }
 }
 

--- a/translation/en.js
+++ b/translation/en.js
@@ -376,6 +376,10 @@ const en = {
   },
   host: {
     title: "Familiada — host",
+    swipeRevealDown: "Swipe down to reveal",
+    swipeCoverUp: "Swipe up to cover",
+    swipeRevealRight: "Swipe right to reveal",
+    swipeCoverLeft: "Swipe left to cover",
   },
   buzzer: {
     title: "Familiada — buzzer",

--- a/translation/pl.js
+++ b/translation/pl.js
@@ -376,11 +376,15 @@ const pl = {
   },
   host: {
     title: "Familiada — prowadzący",
+    swipeRevealDown: "Przesuń w dół, żeby odsłonić",
+    swipeCoverUp: "Przesuń w górę, żeby zasłonić",
+    swipeRevealRight: "Przesuń w prawo, żeby odsłonić",
+    swipeCoverLeft: "Przesuń w lewo, żeby zasłonić",
   },
   buzzer: {
-    title: "Familiada — buzzer",
-    btnA: "Buzzer A",
-    btnB: "Buzzer B",
+    title: "Familiada — przycisk",
+    btnA: "Przycisk A",
+    btnB: "Przycisk B",
   },
 };
 

--- a/translation/uk.js
+++ b/translation/uk.js
@@ -376,9 +376,13 @@ const uk = {
   },
   host: {
     title: "Familiada — ведучий",
+    swipeRevealDown: "Проведіть вниз, щоб відкрити",
+    swipeCoverUp: "Проведіть вгору, щоб закрити",
+    swipeRevealRight: "Проведіть вправо, щоб відкрити",
+    swipeCoverLeft: "Проведіть вліво, щоб закрити",
   },
   buzzer: {
-    title: "Familiada — buzzer",
+    title: "Familiada — кнопка",
     btnA: "Кнопка A",
     btnB: "Кнопка B",
   },


### PR DESCRIPTION
### Motivation
- Keep device UIs (display/host/buzzer) in sync with the control panel language on startup and when language changes. 
- Replace hard-coded Polish swipe hint strings in the host UI with i18n keys so they are translated for PL/UK/EN users. 
- Remove the host-side language switcher so language is controlled from the main control panel while ensuring the app name `Familiada` remains untranslated.

### Description
- Added initial device language sync in `control/js/app.js` by importing `getUiLang`, calling `devices.updateLinksAndQr(initialLang)`, and sending `LANG <lang>` to display/host/buzzer on startup and on `i18n:lang` events. 
- Localized host swipe hint strings in `js/pages/host.js` by importing `t`, switching `initI18n` to `withSwitcher: false`, replacing hard-coded Polish hints with `t('host.*')` keys, and adding an `i18n:lang` listener to refresh hints. 
- Added new translation keys for the host swipe hints in `translation/en.js`, `translation/pl.js`, and `translation/uk.js`. 
- Adjusted PL/UK buzzer strings so button/title labels are localized while leaving `Familiada` unchanged in all titles.

### Testing
- Attempted an integration smoke test by serving the site with `python -m http.server` and running a Playwright script to load `host.html` and capture a screenshot, but the Playwright/Chromium run crashed and the screenshot step failed. 
- Performed automated static checks (repository greps) to verify `LANG` handlers exist and that `data-i18n` keys and new translation keys are present, which matched the expected changes. 
- No further automated unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987ee912cdc83218dac24be57c39ea3)