### PR TITLE
Move manual content into translations and wire manual.html to i18n

### DIFF
--- a/manual.html
+++ b/manual.html
@@ -43,7 +43,7 @@
 
   <!-- OGÓLNY OPIS -->
   <section class="tab-page active" id="tab-general" aria-label="Ogólny opis">
-    <div class="m-doc">
+    <div class="m-doc" data-i18n-html="manual.content.general">
 
       <p class="m-p">
         Ta strona to wskazówki obsługi systemu do prowadzenia rozgrywki (turnieju)
@@ -115,7 +115,7 @@
 
   <!-- POZOSTAŁE KARTY – NA RAZIE PUSTE -->
   <section class="tab-page" id="tab-edit" aria-label="Dodawanie i edycja gry">
-    <div class="m-doc">
+    <div class="m-doc" data-i18n-html="manual.content.edit">
 
       <p class="m-p">
         Zakładka „Dodawanie i edycja gry” opisuje etap przygotowania gry
@@ -333,7 +333,7 @@
 
   <section class="tab-page" id="tab-bases" aria-label="Bazy pytań">
 
-    <div class="m-doc">
+    <div class="m-doc" data-i18n-html="manual.content.bases">
   
       <h2 class="m-h2">Bazy pytań — organizacja i współpraca</h2>
   
@@ -594,7 +594,7 @@
   </section>
 
   <section class="tab-page" id="tab-polls" aria-label="Sondaże">
-    <div class="m-doc">
+    <div class="m-doc" data-i18n-html="manual.content.polls">
     
       <p class="m-p">
         Zakładka „Sondaże” opisuje etap zbierania odpowiedzi
@@ -871,7 +871,7 @@
   </section>
 
 <section class="tab-page" id="tab-logo" aria-label="Tworzenie logo">
-  <div class="m-doc">
+  <div class="m-doc" data-i18n-html="manual.content.logo">
 
     <p class="m-p">
       System pozwala ustawić własne logo, które pojawia się na wyświetlaczu
@@ -956,7 +956,7 @@
 </section>
 
   <section class="tab-page" id="tab-control" aria-label="Panel sterowania">
-    <div class="m-doc">
+    <div class="m-doc" data-i18n-html="manual.content.control">
 
       <p class="m-p">
         Do Panelu sterowania przechodzisz z listy „Moje gry”
@@ -1375,7 +1375,7 @@
   </section>
 
   <section class="tab-page" id="tab-demo">
-    <div class="m-doc">
+    <div class="m-doc" data-i18n-html="manual.content.demo">
   
       <p class="m-p">
         W tej zakładce możesz przywrócić przykładowe materiały startowe:

--- a/translation/en.js
+++ b/translation/en.js
@@ -777,6 +777,1321 @@ const en = {
       modalOk: "Restore",
       modalCancel: "Cancel",
     },
+    content: {
+      general: `<p class="m-p">
+        This page is a guide to running a game (tournament)
+        in the style of “Familiada.” Its goal is to explain how to prepare a game,
+        collect results (polls), and smoothly run a live match
+        — even if someone uses the system for the first time.
+      </p>
+      
+      <p class="m-p">
+        The description focuses on the tool and how to use it,
+        not on “television production.” The system works well for events,
+        company parties, school, stage shows, or just with friends
+        — anywhere you want a clear board, points, and a smooth flow of play.
+      </p>
+      
+      <p class="m-p">
+        The gameplay is structured to closely match the official rules of Familiada
+        (rounds, bank, X errors, steals, and the final), but the whole thing is designed as
+        a convenient system for hosting the game/tournament, with a clear division of roles:
+        <span class="m-strong">the host leads the conversation and asks the questions</span>,
+        while <span class="m-strong">the operator controls the board and points</span>.
+      </p>
+
+      <p class="m-p">
+        If you want to read the full rules of the game,
+        <a href="https://s.tvp.pl/repository/attachment/6/8/f/68f09c03ff0781fa510c2fd90c3ba19b1569224834470.pdf"
+           target="_blank"
+           rel="noopener">
+          The “Familiada” game show rules
+        </a>
+        describe them in detail.
+      </p>
+
+      <p class="m-p">
+        The whole system is designed
+        to clearly separate content preparation
+        from the actual gameplay.
+        Questions, answers, and polls are prepared in advance,
+        while during the game the operator uses only
+        the control panel.
+      </p>
+
+      <p class="m-p">
+        In practice this means that on the day of the recording
+        the operator doesn’t edit data,
+        the host focuses on talking with the contestants,
+        and the system keeps track of stages and game logic.
+        This reduces the risk of mistakes and speeds up the flow of the game.
+      </p>
+
+      <p class="m-p">
+        The system works best when using separate devices:
+        a display for the audience (TV or projector),
+        a tablet or phone for the host,
+        a separate device acting as the buzzer,
+        and the operator’s computer with the control panel.
+      </p>
+
+      <p class="m-p">
+        The guide is divided into tabs.
+        Each tab describes a different stage of working with the system:
+        from preparing the game,
+        through polls,
+        to running the live gameplay.
+      </p>`,
+      edit: `<p class="m-p">
+        The “Creating and editing a game” tab describes the stage of preparing the game
+        before starting the poll or the live match.
+        At this stage you create the structure of the game:
+        questions, possible answers, and how they are scored.
+      </p>
+    
+      <p class="m-p">
+        This stage is key, because it determines
+        how all later work with the game will look.
+        The system deliberately separates content preparation
+        from later data collection and live gameplay.
+      </p>
+    
+      <h3 class="m-h2">Game list (“My games”)</h3>
+    
+      <p class="m-p">
+        The game list is the place where you manage all games
+        assigned to your account.
+        This is where you can create new games,
+        choose existing ones,
+        and decide what you want to do next.
+      </p>
+    
+      <p class="m-p">
+        Games are divided into types.
+        The game type determines how answers will be collected
+        and how points will be generated on the board later.
+      </p>
+    
+      <ul class="m-ul">
+        <li>
+          <span class="m-strong">Standard poll</span> —
+          answers are typed in by respondents,
+          and points are based on the number of mentions.
+        </li>
+        <li>
+          <span class="m-strong">Answer scoring</span> —
+          respondents choose from prepared answers,
+          and the system counts votes.
+        </li>
+        <li>
+          <span class="m-strong">Prepared</span> —
+          answers and points are set manually,
+          without a poll.
+        </li>
+      </ul>
+    
+      <p class="m-p">
+        You create a new game by clicking the tile with the “＋” symbol.
+        After creation the game appears on the list
+        and can be opened in the editor.
+      </p>
+    
+      <h3 class="m-h2">Game editor — what and when can be edited</h3>
+    
+     <p class="m-p">
+        You enter the game edit mode from the “My games” list
+        using the <span class="m-code">Edit</span> button.
+        This is the first stage of working on the game,
+        where you prepare its full content
+        before using it in a poll or live gameplay.
+      </p>
+      
+      <p class="m-p">
+        In edit mode you create questions and answers,
+        decide on the game type,
+        and prepare the structure
+        that will later be used
+        to collect data or run the live game.
+      </p>
+      
+      <p class="m-p">
+        The game editor is used to build the structure of questions and answers.
+        Depending on the game type and its state,
+        the available editing options may differ.
+      </p>
+    
+      <p class="m-p">
+        This is intentional.
+        The system limits certain operations
+        to keep data consistent
+        and prevent situations
+        where the gameplay or poll
+        no longer matches the prepared content.
+      </p>
+    
+      <h3 class="m-h3">Adding and editing questions</h3>
+    
+      <p class="m-p">
+        Questions are always the core element of the game.
+        During preparation you can:
+        add new questions,
+        change their wording,
+        and remove unnecessary questions.
+      </p>
+    
+      <p class="m-p">
+        Changing a question after a poll has started
+        may be blocked,
+        because even a small text change
+        affects the meaning of collected answers.
+      </p>
+    
+      <h3 class="m-h3">Adding and editing answers</h3>
+    
+      <p class="m-p">
+        The ability to edit answers depends on the game type.
+        In poll-based games answers are the result of a survey,
+        so before the poll you can only prepare
+        their general structure or examples.
+      </p>
+    
+      <p class="m-p">
+        After the poll starts, the system may limit
+        adding or removing answers
+        so that responses from respondents
+        are not mixed with new content.
+      </p>
+    
+      <h3 class="m-h3">Points — why they are sometimes locked</h3>
+    
+      <p class="m-p">
+        Points are not always editable by hand.
+        In poll-based games points result directly
+        from the number of answers given,
+        so manual editing makes no sense
+        and is blocked.
+      </p>
+    
+      <p class="m-p">
+        Manual point setting is possible
+        only in prepared mode,
+        where the system does not use survey data.
+      </p>
+    
+      <div class="m-note">
+        <b>Why is that?</b><br/>
+        Thanks to this, what the audience sees on the board
+        always matches the actual poll results
+        or a clearly defined, manual scoring.
+      </div>
+    
+      <h3 class="m-h2">Length and format limits</h3>
+    
+      <p class="m-p">
+        Answers should be short and readable.
+        When importing content, answers longer
+        than <span class="m-strong">17 characters</span>
+        are automatically trimmed.
+      </p>
+    
+      <p class="m-p">
+        This limit comes from the board layout
+        and aims to keep things readable
+        during live gameplay.
+      </p>
+    
+      <h3 class="m-h2">Importing and exporting games</h3>
+    
+      <p class="m-p">
+        Builder allows exporting and importing games
+        as files or directly into a question base.
+        This feature is used to move games and questions
+        between accounts or environments.
+      </p>
+    
+      <p class="m-p">
+        Import and export files are a technical format.
+        You should not alter their contents
+        or try to edit them manually.
+      </p>
+    
+      <div class="m-warn">
+        <b>Warning:</b>
+        manual modification of import or export files
+        can make a game impossible to import
+        or cause it to work incorrectly.
+      </div>
+    
+      <p class="m-p">
+        After a successful import, the game appears
+        in the game list and can be further edited
+        only using the system editor.
+      </p>
+      
+      <p class="m-p">
+        When exporting a game to a base:
+      </p>
+      
+      <ul class="m-ul">
+        <li>a new folder is created in the base root</li>
+        <li>the folder is named after the game</li>
+        <li>all questions belonging to the game are saved inside</li>
+      </ul>
+
+      <p class="m-note">
+        You can export only to your own base or to a shared base where you are an editor.
+        If you do not currently have any bases, you will not be able to export.
+      </p>
+      
+      <p class="m-p">
+        Thanks to this each game can be turned into a set of questions for further editing,
+        organizing into folders, tagging, and reusing
+        in future games.
+      </p>
+      
+      <p class="m-note">
+        Exporting to a base does not remove the game — it only creates a copy as a question structure.
+      </p>`,
+      bases: `<h2 class="m-h2">Question bases — organization and collaboration</h2>
+  
+      <p class="m-p">
+        Question bases are a central place for storing all questions used in games.
+        They let you organize questions in folders, tag them, assign categories,
+        and share entire bases with other users.
+      </p>
+      <p class="m-p">
+        You access question bases from the top bar of the “My games” page
+        using the <span class="m-code">Question bases 🗃️</span> button.
+      </p>
+  
+      <p class="m-p">
+        A single base can contain hundreds or thousands of questions organized in a structure similar
+        to a classic file manager on a computer.
+      </p>
+  
+      <h3 class="m-h3">➕ Adding a new base</h3>
+  
+      <p class="m-p">
+        In the “Question bases” view click the <span class="m-strong">New base</span> tile.
+        A window will open where you enter the base name.
+      </p>
+  
+      <p class="m-p">
+        After saving, the new base appears in the list and you can immediately browse or share it.
+      </p>
+  
+      <h3 class="m-h3">🤝 Sharing a base</h3>
+  
+      <p class="m-p">
+        You can share any base with other users by providing their email address.
+        Two modes are available:
+      </p>
+  
+      <ul class="m-ul">
+        <li><span class="m-strong">Edit</span> — the user can add, delete, and modify questions, folders, tags, create games from questions, and export questions to a base</li>
+        <li><span class="m-strong">View</span> — the user can only browse the base and create games from available questions</li>
+      </ul>
+  
+      <p class="m-p">
+        Only the base owner can manage sharing.
+      </p>
+  
+      <h3 class="m-h3">📂 Opening the base manager</h3>
+  
+      <p class="m-p">
+        To enter a base, select it in the list and click the <span class="m-code">Browse</span> button.
+      </p>
+  
+      <p class="m-p">
+        Base Explorer will open — an advanced question manager that works like a classic file explorer.
+      </p>
+  
+      <h2 class="m-h2">Base Explorer — question manager</h2>
+  
+      <p class="m-p">
+        Base Explorer lets you manage questions in a way familiar from system file managers:
+        folders, drag-and-drop moves, copy, cut, and quick selection.
+      </p>
+  
+      <p class="m-p">
+        Each “file” in this manager is a single question.
+        Folders are used to group questions thematically or logically.
+      </p>
+  
+      <p class="m-p">
+        You can:
+      </p>
+  
+      <ul class="m-ul">
+        <li>create arbitrarily nested folders</li>
+        <li>move questions and folders between each other</li>
+        <li>copy and duplicate items</li>
+        <li>delete selected items</li>
+        <li>search by name and tags</li>
+      </ul>
+  
+      <p class="m-note">
+        The interface and keyboard shortcuts work similarly to classic file managers
+        (Explorer, Finder, Total Commander).
+      </p>
+  
+      <h2 class="m-h2">Tags and categories</h2>
+  
+      <h3 class="m-h3">🏷️ Tags</h3>
+  
+      <p class="m-p">
+        Each question can have any number of tags.
+        Tags are used to label questions by topic — e.g. “history,” “sports,” “easy,” “for kids.”
+      </p>
+  
+      <p class="m-p">
+        You can:
+      </p>
+  
+      <ul class="m-ul">
+        <li>create your own tags with colors</li>
+        <li>assign multiple tags to a single question</li>
+        <li>filter the view by selected tags</li>
+      </ul>
+
+      <p class="m-p">
+        Tag assignment takes place in a dedicated window, which you can open from the toolbar
+        or the context menu.
+      </p>
+      
+      <p class="m-p">
+        In the tag assignment window you can see a list of all available tags and their states:
+      </p>
+      
+      <ul class="m-ul">
+        <li>selected — the tag is assigned to all selected items</li>
+        <li>unselected — the tag is assigned to none of them</li>
+        <li>partial — only part of the selection has the tag</li>
+      </ul>
+      
+      <p class="m-p">
+        Clicking a tag cycles its state, enabling quick adding and removing of tags
+        for many questions or folders at once. This window also allows creating new tags.
+      </p>
+      
+      <p class="m-p">
+        Tags can also be used as filters — clicking a tag on the left narrows the view
+        to items marked with the selected tag or tag set.
+      </p>
+  
+      <p class="m-note">
+        A folder shows tag markers when all questions inside it
+        (and subfolders) have the same tag.
+      </p>
+  
+      <h3 class="m-h3">📌 Categories</h3>
+  
+      <p class="m-p">
+        Categories are special system labels that indicate
+        which game type a given question fits. This corresponds to game types in the <span class="m-strong">My games</span> view.
+      </p>
+  
+      <p class="m-p">
+        For example:
+      </p>
+  
+      <ul class="m-ul">
+        <li>questions with answers and points go to the <span class="m-strong">prepared</span> category</li>
+        <li>questions with answers but no points total go to <span class="m-strong">scoring</span></li>
+        <li>text-only questions without points go to <span class="m-strong">standard</span></li>
+      </ul>
+  
+      <p class="m-p">
+        Categories are assigned automatically based on the question structure,
+        not manually by the user.
+      </p>
+  
+      <p class="m-note">
+        This way you immediately know which questions suit a specific game type.
+      </p>
+  
+      <h2 class="m-h2">Question editor</h2>
+  
+      <p class="m-p">
+        You can open any question in the editor.
+        The editor lets you change the question text, answers, and points (if present).
+      </p>
+  
+      <p class="m-p">
+        The system enforces basic rules such as:
+      </p>
+  
+      <ul class="m-ul">
+        <li>the maximum number of points for a single answer</li>
+        <li>the total sum of points in a question</li>
+      </ul>
+  
+      <p class="m-p">
+        Thanks to this the base always stays consistent and ready for use in games.
+      </p>
+  
+      <h2 class="m-h2">Creating a game from questions</h2>
+  
+      <p class="m-p">
+        In the base manager you can select any questions and folders (including subfolders),
+        and then create a new game from them.
+      </p>
+  
+      <p class="m-p">
+        The system collects all questions from the selection, lets you review them,
+        and choose the game type.
+      </p>
+
+      <p class="m-note">
+        This enables fast game building from ready sets of questions without manual retyping.
+      </p>
+
+      <p class="m-warn">
+        After successful game creation you will be redirected to the <span class="m-strong">My games</span> view.
+      </p>
+  
+      <h2 class="m-h2">⌨️ Keyboard shortcuts — Base manager</h2>
+  
+      <h3 class="m-h3">📁 Create</h3>
+  
+      <table class="m-table">
+        <tr><th>Action</th><th>Windows / Linux</th><th>macOS</th></tr>
+        <tr><td>New question</td><td>Ctrl + N</td><td>⌘ N</td></tr>
+        <tr><td>New folder</td><td>Ctrl + Shift + N</td><td>⌘ ⇧ N</td></tr>
+      </table>
+  
+      <h3 class="m-h3">✏️ Edit</h3>
+  
+      <table class="m-table">
+        <tr><th>Action</th><th>Windows / Linux</th><th>macOS</th></tr>
+        <tr><td>Edit question</td><td>Ctrl + E</td><td>⌘ E</td></tr>
+        <tr><td>Rename</td><td>F2</td><td>F2</td></tr>
+        <tr><td>Delete</td><td>Delete</td><td>Fn + ⌫</td></tr>
+      </table>
+  
+      <h3 class="m-h3">📋 Clipboard</h3>
+  
+      <table class="m-table">
+        <tr><th>Action</th><th>Windows / Linux</th><th>macOS</th></tr>
+        <tr><td>Copy</td><td>Ctrl + C</td><td>⌘ C</td></tr>
+        <tr><td>Cut</td><td>Ctrl + X</td><td>⌘ X</td></tr>
+        <tr><td>Paste</td><td>Ctrl + V</td><td>⌘ V</td></tr>
+        <tr><td>Duplicate</td><td>Ctrl + D</td><td>⌘ D</td></tr>
+      </table>
+  
+      <h3 class="m-h3">🎮 Game</h3>
+  
+      <table class="m-table">
+        <tr><th>Action</th><th>Windows / Linux</th><th>macOS</th></tr>
+        <tr><td>Create game</td><td>Ctrl + G</td><td>⌘ G</td></tr>
+      </table>
+  
+      <h3 class="m-h3">🔄 View</h3>
+  
+      <table class="m-table">
+        <tr><th>Action</th><th>Windows / Linux</th><th>macOS</th></tr>
+        <tr><td>Refresh view</td><td>Ctrl + Alt + R</td><td>⌘ ⌥ R</td></tr>
+      </table>
+  
+      <h3 class="m-h3">📌 Navigation</h3>
+  
+      <table class="m-table">
+        <tr><th>Action</th><th>Windows / Linux</th><th>macOS</th></tr>
+        <tr><td>Select all</td><td>Ctrl + A</td><td>⌘ A</td></tr>
+        <tr><td>Open folder</td><td>Enter</td><td>⏎</td></tr>
+        <tr><td>Parent folder</td><td>Backspace</td><td>⌫</td></tr>
+      </table>
+  
+      <p class="m-note">
+        Shortcuts do not work while typing in edit fields.
+      </p>`,
+      polls: `<p class="m-p">
+        The “Polls” tab describes the stage of collecting responses
+        from respondents before the live match.
+        The poll is a bridge between game preparation
+        and the live gameplay.
+      </p>
+    
+      <p class="m-p">
+        At this stage the system stops being a content editor
+        and starts working as a data collection tool.
+        For this reason many editing options are deliberately limited.
+      </p>
+
+      <p class="m-p">
+        You reach polls from the “My games” list
+        using the <span class="m-code">Polls Hub</span> button.
+        This stage happens after finishing game editing
+        and is used only to collect responses
+        or votes from respondents.
+      </p>
+      
+      <p class="m-p">
+        When a poll starts,
+        the game stops being editable
+        and begins serving as a data collection tool.
+        Therefore some options available in the editor
+        are deliberately blocked in this mode.
+      </p>
+
+      <h3 class="m-h2">Polls hub (polls-hub)</h3>
+
+      <p class="m-p">
+        The polls hub is a separate panel for managing polls, tasks, and subscriptions.
+        You open it from the “My games” list with the <span class="m-code">Polls Hub</span> button.
+        On desktop you see two cards, each with two lists.
+      </p>
+
+      <ul class="m-ul">
+        <li><span class="m-strong">Polls</span> — the “My polls” list and “Tasks.”</li>
+        <li><span class="m-strong">Subscriptions</span> — the “My subscribers” list and “My subscriptions.”</li>
+      </ul>
+
+      <p class="m-p">
+        The gold dot on the “Polls” card shows the number of active tasks to complete,
+        and on the “Subscriptions” card the number of invitations to accept.
+      </p>
+
+      <p class="m-p">
+        A subscription is a permanent connection between your account and an invited user —
+        once accepted, it allows sharing future polls without re-entering the email.
+        You send an invitation in the “My subscribers” section by entering an email or username
+        and clicking <span class="m-code">Invite</span>. The recipient accepts the invite in their
+        Polls Hub or via the link in the message, and the status becomes active.
+      </p>
+
+      <p class="m-p">
+        Sharing a poll is done from the “My polls” list: select the tile and click
+        <span class="m-code">Share</span>, then choose subscribers and save.
+        The poll tile shows current votes, and the <span class="m-code">Details</span> button
+        provides a view of submitted votes, pending, rejected, and anonymous responses.
+      </p>
+
+      <h3 class="m-h3">My polls</h3>
+      <p class="m-p">
+        Each tile has a color that indicates the poll status:
+      </p>
+      <ul class="m-ul">
+        <li><span class="m-strong">Gray</span> — draft, missing requirements to start.</li>
+        <li><span class="m-strong">Red</span> — draft ready to start.</li>
+        <li><span class="m-strong">Orange</span> — poll open, no votes.</li>
+        <li><span class="m-strong">Yellow</span> — poll open, there are votes or active tasks.</li>
+        <li><span class="m-strong">Green</span> — poll open, goals reached (tasks done or ≥10 votes).</li>
+        <li><span class="m-strong">Blue</span> — poll closed.</li>
+      </ul>
+
+      <h3 class="m-h3">Tasks</h3>
+      <p class="m-p">
+        Tasks are voting invitations. Colors:
+        <span class="m-strong">green</span> — available,
+        <span class="m-strong">blue</span> — completed.
+        Double-click opens voting, and the <span class="m-code">X</span> button rejects the task.
+      </p>
+
+      <h3 class="m-h3">My subscribers</h3>
+      <p class="m-p">
+        Status colors:
+        <span class="m-strong">yellow</span> — pending,
+        <span class="m-strong">green</span> — active,
+        <span class="m-strong">red</span> — rejected/canceled.
+        The <span class="m-code">X</span> button removes a subscriber, and <span class="m-code">↻</span> resends an invite.
+      </p>
+
+      <h3 class="m-h3">My subscriptions</h3>
+      <p class="m-p">
+        Colors:
+        <span class="m-strong">yellow</span> — pending,
+        <span class="m-strong">green</span> — active.
+        Buttons: <span class="m-code">✓</span> accepts, <span class="m-code">X</span> rejects/cancels.
+      </p>
+
+    
+      <h3 class="m-h2">Types of polls</h3>
+    
+      <p class="m-p">
+        Depending on the game type, a poll can work in one of two modes:
+      </p>
+    
+      <ul class="m-ul">
+        <li>
+          <span class="m-strong">Standard (text) poll</span> —
+          respondents type their own text answers.
+        </li>
+        <li>
+          <span class="m-strong">Scoring poll</span> —
+          respondents choose one of the prepared answers.
+        </li>
+      </ul>
+    
+      <p class="m-p">
+        Prepared games do not have a poll —
+        answers and points are set manually.
+      </p>
+    
+      <h3 class="m-h2">Starting a poll</h3>
+    
+      <p class="m-p">
+        A poll can be started only for a game
+        in the <span class="m-strong">Draft</span> state.
+        Before starting, the system checks
+        whether the game meets the minimum requirements.
+      </p>
+    
+      <ul class="m-ul">
+        <li>minimum number of questions,</li>
+        <li>in scoring mode — the required number of answers per question.</li>
+      </ul>
+    
+      <div class="m-note">
+        <b>Why?</b><br/>
+        This ensures you cannot start a poll
+        that cannot later be properly closed
+        and used in the game.
+      </div>
+    
+      <h3 class="m-h2">Link and QR code</h3>
+    
+      <p class="m-p">
+        After starting a poll the system generates
+        a unique voting link.
+        The link can be copied,
+        opened in a new tab,
+        or displayed as a QR code.
+      </p>
+    
+      <p class="m-p">
+        The QR code is intended to be displayed
+        on a screen visible to respondents
+        (TV, projector, large monitor).
+      </p>
+    
+      <h3 class="m-h2">Poll flow</h3>
+    
+      <p class="m-p">
+        Respondents go through the questions in order.
+        The system enforces the order
+        and does not allow skipping a question.
+      </p>
+    
+      <p class="m-p">
+        In a text poll each answer:
+      </p>
+    
+      <ul class="m-ul">
+        <li>is limited to 17 characters,</li>
+        <li>is normalized (case, spaces),</li>
+        <li>is counted as a separate proposal.</li>
+      </ul>
+    
+      <p class="m-p">
+        In a scoring poll the respondent
+        chooses one of the prepared answers,
+        and the system records the vote.
+      </p>
+    
+      <h3 class="m-h2">Closing a poll</h3>
+    
+      <p class="m-p">
+        Closing a poll is a separate,
+        deliberate stage of work.
+        The system will not allow closing a poll
+        if the collected data does not meet
+        minimum quality conditions.
+      </p>
+    
+      <h3 class="m-h3">Scoring poll</h3>
+    
+      <p class="m-p">
+        When closing a scoring poll
+        the system converts votes into points
+        and normalizes them to a 0–100 scale
+        for each question.
+      </p>
+    
+      <div class="m-note">
+        <b>Result:</b>
+        you get a ready list of answers with points,
+        without the need for manual counting.
+      </div>
+    
+      <h3 class="m-h3">Text poll</h3>
+    
+      <p class="m-p">
+        In a text (classic) poll respondents type their own answers.
+        After closing, the system moves to the results cleanup stage.
+        The operator can merge obviously similar answers
+        and remove typos or clear duplicates.
+      </p>
+      
+      <p class="m-p">
+        Then answers are normalized to the points scale.
+        At this stage the system applies additional limits
+        aimed at keeping the board readable
+        and the gameplay dynamic.
+      </p>
+      
+      <p class="m-p">
+        Answers with a very low number of mentions
+        that after normalization get
+        <span class="m-strong">less than 8 points</span>
+        are automatically discarded.
+        Such answers usually do not matter for the game
+        and would not be readable for the audience.
+      </p>
+      
+      <p class="m-p">
+        For one question, the board can show at most
+        <span class="m-strong">6 answers</span>.
+        If there are more correct answers,
+        the system selects the highest-scoring ones
+        and skips the rest.
+      </p>
+      
+      <p class="m-p">
+        For this reason the total points for a single question
+        <span class="m-strong">do not always sum to exactly 100</span>.
+        Points are assigned only to the answers
+        that actually appear on the board.
+      </p>
+    
+      <div class="m-warn">
+        <b>Warning:</b>
+        after closing a poll
+        you cannot change its results
+        without restarting the poll.
+      </div>
+    
+      <h3 class="m-h2">Restarting a poll</h3>
+    
+      <p class="m-p">
+        A closed poll can be restarted,
+        which removes previous results
+        and starts collecting answers from scratch.
+      </p>
+    
+      <p class="m-p">
+        This option is useful
+        when the poll was started for testing
+        or an organizational error occurred.
+      </p>`,
+      logo: `<p class="m-p">
+      The system lets you set your own logo that appears on the display
+      (e.g., the start or end screen). You can access the logo creator from the top bar of the “My games” page
+        using the <span class="m-code">Logo🖥️</span> button.
+    </p>
+
+    <div class="m-note">
+      <b>Important:</b><br/>
+      The logo has a technical size of <span class="m-code">30×10</span> (character tiles) or <span class="m-code">150×70</span> (pixels).
+      This limitation comes from the physical layout of the board and ensures readability live.
+    </div>
+
+    <h3 class="m-h2">Logo creation modes</h3>
+
+    <p class="m-p">
+      When creating a new logo you choose one of the modes.
+      Each mode leads to the same result (a logo on the display),
+      but differs in how it is created.
+    </p>
+
+    <ul class="m-ul">
+      <li>
+        <span class="m-strong">Text art</span> — a classic logo made of characters (the “Familiada” style).
+        Good when you want a quick, readable title.
+      </li>
+      <li>
+        <span class="m-strong">Text</span> — text editing and preview in “pixels.”
+        Good when you need a different font/layout than “Text art.”
+      </li>
+      <li>
+        <span class="m-strong">Drawing</span> — draw by hand on a grid (like a simple graphics editor).
+        Good for icons and simple shapes.
+      </li>
+      <li>
+        <span class="m-strong">Image</span> — import an image and fit it to the board.
+        Good when you already have a company logo.
+      </li>
+    </ul>
+
+    <h3 class="m-h2">Display preview</h3>
+
+    <p class="m-p">
+      In the editor you always see a preview “as on the board.”
+      This is important because what looks good in high resolution
+      may be unreadable when reduced to <span class="m-code">150×70</span>.
+    </p>
+
+    <div class="m-note">
+      <b>Practical tip:</b><br/>
+      Thick shapes, large letters, and high contrast work best.
+      Thin lines, small details, and subtle gradients usually disappear.
+    </div>
+
+    <h3 class="m-h2">Saving and active logo</h3>
+
+    <p class="m-p">
+      You can save a logo under your own name. In the logo list you can also set
+      which logo is <span class="m-strong">active</span>.
+      The active logo will be used by the display automatically.
+    </p>
+
+    <p class="m-p">
+      If you do not set any active logo, the system uses
+      the <span class="m-strong">default logo</span>.
+    </p>
+
+    <h3 class="m-h2">Logo import and export</h3>
+
+    <p class="m-p">
+      The editor allows exporting the active logo to a file and importing a logo from a file.
+      This lets you move logos between accounts or make backups.
+    </p>
+
+    <div class="m-warn">
+      <b>Warning:</b><br/>
+      Do not edit logo files manually. This is a technical format — manual changes may cause
+      the import to fail or the logo to work incorrectly.
+    </div>`,
+      control: `<p class="m-p">
+        You reach the Control Panel from the “My games” list
+        using the <span class="m-code">Play</span> button.
+        This mode is intended only for running the live game —
+        you no longer edit questions or poll results here.
+      </p>
+    
+      <p class="m-p">
+        The control panel guides the operator step by step:
+        first you connect devices, then set game parameters,
+        and finally go through rounds and (optionally) the final.
+        Each step unlocks only when the previous one is ready,
+        which minimizes the risk of mistakes during recording.
+      </p>
+    
+      <h3 class="m-h2">What must be ready before you start</h3>
+    
+      <ul class="m-ul">
+        <li>
+          The game should have prepared questions and answers (from the editor),
+          and if it is a poll-based game — the poll should be closed and approved.
+        </li>
+        <li>
+          The operator should have a computer with a large screen (the panel is designed for desktop mode).
+        </li>
+        <li>
+          Separate devices should be prepared: a display (TV/projector), the host’s device,
+          and a device acting as the buzzer.
+        </li>
+        <li>
+          Stable Wi-Fi (the most common issues are killed background tabs / network switching).
+        </li>
+      </ul>
+    
+      <div class="m-note">
+        <b>Why so many “formalities”?</b><br/>
+        The gameplay is live and has a TV pace. The control panel is meant to enforce the procedure,
+        not add stress for the operator. That’s why the system requires readiness of equipment and settings before starting.
+      </div>
+    
+      <h3 class="m-h2">Who sees what</h3>
+    
+      <p class="m-p">
+        The system deliberately separates screens so everyone does their job:
+      </p>
+    
+      <ul class="m-ul">
+        <li>
+          <span class="m-strong">Operator (Control Panel)</span> — sees all buttons,
+          game status, bank, Xs, messages, and the next procedural steps.
+          The operator controls what appears on the board.
+        </li>
+        <li>
+          <span class="m-strong">Display</span> — shows the game board: questions, answers,
+          points, bank, errors (X), and start/end screens.
+          This is the screen visible to participants and the audience.
+        </li>
+        <li>
+          <span class="m-strong">Host</span> — receives content to read and a context preview,
+          but does not control the course of the game (the operator does).
+        </li>
+        <li>
+          <span class="m-strong">Buzzer</span> — used to signal the face-off (who is first).
+        </li>
+      </ul>
+    
+      <h3 class="m-h2">1) Devices</h3>
+    
+      <p class="m-p">
+        The first stage in the panel is connecting devices.
+        In the top bar you see three statuses:
+        <span class="m-strong">Display</span>,
+        <span class="m-strong">Host</span>,
+        <span class="m-strong">Buzzer</span>.
+        The operator starts by making sure all are online.
+      </p>
+    
+      <h3 class="m-h3">Step 1: Display</h3>
+    
+      <p class="m-p">
+        In this step the panel shows a QR code and link for the display.
+        It’s best to open the display on a TV or projector,
+        in full-screen mode (no browser bars).
+        Only when the display is online will the panel allow you to proceed.
+      </p>
+    
+      <h3 class="m-h3">Step 2: Host and buzzer</h3>
+    
+      <p class="m-p">
+        In the second step you connect the host device and the buzzer device.
+        The panel also shows a QR/link for connection.
+        In practice it’s best to use two separate phones or a phone and a tablet.
+      </p>
+    
+      <p class="m-p">
+        In this step there is an option <span class="m-strong">“QR on display”</span> —
+        after using it the QR codes can be shown on the large screen,
+        so the crew can quickly scan them with phones.
+        This speeds up the start on set because there is no need to type links manually.
+      </p>
+    
+      <div class="m-warn">
+        <b>Warning:</b><br/>
+        If any device disconnects during the game, the panel can show a warning.
+        Most often it helps to disable battery saving, avoid minimizing the browser,
+        and keep devices on one stable Wi-Fi network.
+      </div>
+    
+      <h3 class="m-h3">Step 3: Sound</h3>
+    
+      <p class="m-p">
+        Browsers block automatic sound playback
+        until the user performs a “gesture” (click).
+        That’s why the panel has a separate step to unlock sound.
+        Without it you may not hear signals that help keep the game pace.
+      </p>
+    
+      <h3 class="m-h2">2) Settings</h3>
+    
+      <p class="m-p">
+        When devices are online, you move on to game settings.
+        This stage has two goals:
+        (1) prepare readable team names on the board,
+        (2) adjust game parameters to the recording (additional settings).
+      </p>
+    
+      <h3 class="m-h3">Team names</h3>
+    
+      <p class="m-p">
+        You set the names of Team A and Team B.
+        These are the labels seen by players and the audience on the display,
+        so it’s best to decide them before the rounds begin.
+        The panel blocks moving forward until both names are entered.
+      </p>
+    
+      <h3 class="m-h3">Additional settings (important for the operator)</h3>
+    
+      <p class="m-p">
+        In “Additional settings” you tailor the game to the episode format.
+        These options do not change the rules’ meaning, only the pace and thresholds.
+      </p>
+    
+      <ul class="m-ul">
+        <li>
+          <span class="m-strong">Round multipliers</span> — entered comma-separated (e.g. <span class="m-code">1,1,1,2,3</span>).
+          This matches the classic doubling/tripling values in later stages.
+          In practice: the round bank at the end is multiplied by the current round multiplier.
+        </li>
+        <li>
+          <span class="m-strong">Game target</span> — the point threshold after which the game can go to the final
+          (in the classic format often 300). This lets you adjust the game length.
+        </li>
+        <li>
+          <span class="m-strong">Final target</span> — the point threshold in the final (default 200 in the classic format).
+        </li>
+        <li>
+          <span class="m-strong">Game ending</span> — what the display shows at the end
+          (logo / points / final prize). This is production-important: the “last frame.”
+        </li>
+      </ul>
+    
+      <div class="m-note">
+        <b>Why is this in the Control Panel and not in the editor?</b><br/>
+        Because these are episode (production) settings, not question content.
+        Questions shouldn’t change during the game, but game parameters sometimes do.
+      </div>
+    
+      <h3 class="m-h3">Final: enable and choose 5 questions</h3>
+    
+      <p class="m-p">
+        If the game should have a final, you enable it and choose exactly <span class="m-strong">5 final questions</span>.
+        The panel shows a list of questions and a list “Final questions (max 5)”.
+        After selecting five, you use the <span class="m-strong">Confirm</span> button.
+      </p>
+    
+      <div class="m-warn">
+        <b>Warning:</b><br/>
+        The final requires 5 confirmed questions before rounds start.
+        This is an intentional lock — in live play there’s no time to pick questions “on the fly.”
+        If you want to change the set, use the <span class="m-strong">Edit</span> mode for final questions.
+      </div>
+    
+      <h3 class="m-h2">3) Rounds — gameplay step by step</h3>
+    
+      <p class="m-p">
+        In rounds you conduct the main gameplay: questions, answers, points, and the round bank.
+        Players see the board on the display, the host asks questions and keeps the flow,
+        while the operator reveals answers, counts points, and adds errors (X).
+      </p>
+      
+      <p class="m-p">
+        The most important practical rule: the host focuses on the contestants,
+        and the operator on running the system. This keeps the game smooth,
+        and the board always shows what it should at any moment.
+      </p>
+    
+      <h3 class="m-h3">Round start: “Game ready” and intro</h3>
+    
+      <p class="m-p">
+        When starting rounds, the panel first prepares the display (clears the board and sets the game state),
+        and then lets you start the intro.
+        This organizes the beginning of the recording: the audience gets a clear start,
+        and the operator has a clear moment to enter the first question.
+      </p>
+    
+      <h3 class="m-h3">Face-off: who takes control</h3>
+    
+      <p class="m-p">
+        Each question starts with the “family heads” face-off at the podium.
+        At this moment the <span class="m-strong">Buzzer</span> device is key:
+        the signal from the buzzer tells the panel someone pressed first.
+        The operator confirms which side gains priority,
+        and the host moves on to the answers.
+      </p>
+    
+      <p class="m-p">
+        According to the rules, if the first answer is not the highest-scoring,
+        the second “head” can answer better and take control.
+        The panel guides the operator through the round control decision,
+        and the display shows which team is currently playing (team indicator).
+      </p>
+
+      <h3 class="m-h3">Giving up the question</h3>
+    
+      <p class="m-p">
+        According to game arrangements, after gaining control a team can also decide
+        that it <span class="m-strong">gives up the question</span> to the opponents.
+        This is a tactical move: instead of “finishing” the question, the team can pass the chance to rivals.
+        The panel provides this option only at the right moment and ensures it cannot be abused.
+      </p>
+    
+      <h3 class="m-h3">Playing the question: revealing answers and the bank</h3>
+    
+      <p class="m-p">
+        After control is set, the team answers and the operator reveals the correct answers on the board.
+        Each correct answer adds points to the <span class="m-strong">round bank</span>.
+        The bank is visible on the display and grows with each correct answer.
+      </p>
+    
+      <p class="m-p">
+        Gameplay continues until:
+        all answers are revealed,
+        or the team loses three “chances” (three Xs),
+        then the operator ends the stage and moves to the steal (when conditions are met).
+      </p>
+    
+      <h3 class="m-h3">Misses (X) and the 3-second limit</h3>
+    
+      <p class="m-p">
+        A wrong answer is marked with an <span class="m-strong">X</span> on the board.
+        Three errors mean losing control and giving a steal attempt to the opponents.
+        The system also has a <span class="m-strong">3-second</span> time limit for answers —
+        exceeding the limit is treated as a miss (X).
+      </p>
+    
+      <div class="m-note">
+        <b>Why a timer?</b><br/>
+        It’s a “whip for pace.” The timer lets the operator close hesitation quickly
+        without debate and keep the rhythm of the game.
+      </div>
+    
+      <h3 class="m-h3">Stealing the bank (one answer)</h3>
+    
+      <p class="m-p">
+        When the playing team uses three “chances” before revealing all answers,
+        the question passes to the opposing team.
+        The opponents get <span class="m-strong">one answer</span>:
+        if they hit — the bank goes to them,
+        if not — the bank stays with the playing team.
+        This closes the question and the round according to the rules.
+      </p>
+    
+      <h3 class="m-h3">Revealing missing answers and ending the round</h3>
+    
+      <p class="m-p">
+        After the question is resolved the operator can reveal missing answers “for information,”
+        so the audience sees the full board.
+        Then the operator ends the round: the bank is added to the correct team,
+        taking the round multiplier into account.
+      </p>
+    
+      <div class="m-note">
+        <b>Practical note:</b><br/>
+        The panel deliberately separates “playing the question” from “ending the round.”
+        This way the operator doesn’t accidentally clear the board state
+        before the host delivers the punchline or before “thank you” is said.
+      </div>
+
+      <h3 class="m-h3">Ending rounds and moving on</h3>
+      
+      <p class="m-p">
+        After each round the system updates team scores and checks
+        whether the end-of-game condition has been met (set in “Additional settings”).
+        Most often it’s a points threshold, e.g. <span class="m-strong">300</span>,
+        but it can be different — depending on how you want to run the tournament.
+      </p>
+      
+      <p class="m-p">
+        If the final is <span class="m-strong">enabled</span> and the round-end condition is met,
+        the game moves to the final.
+        If the final is <span class="m-strong">disabled</span>, the game ends after rounds
+        and the system goes to the ending screen (logo/points/prize — according to settings).
+      </p>
+      
+      <div class="m-warn">
+        <b>Warning:</b><br/>
+        If the game runs out of questions during play
+        before the points threshold is reached,
+        the system ends rounds due to lack of questions.
+        Then the game moves to the final (if enabled)
+        or to the ending (if the final is disabled).
+      </div>
+    
+    <h3 class="m-h2">4) Final</h3>
+
+      <p class="m-p">
+        The final is a separate game mode. Two contestants
+        from the team that won the main game take part.
+        They answer the same <span class="m-strong">5 questions</span>,
+        and their points are summed. The goal is to reach the final threshold
+        (default <span class="m-strong">200 points</span>, unless set otherwise).
+      </p>
+      
+      <h3 class="m-h3">Final preparation</h3>
+      
+      <p class="m-p">
+        Before starting the final, in game settings you must have selected and confirmed
+        <span class="m-strong">exactly 5 final questions</span>.
+        This ensures the final is ready to run without searching for questions during play.
+      </p>
+      
+      <p class="m-p">
+        The second contestant should not know the first contestant’s answers.
+        In practice, during the first contestant’s turn
+        the second contestant turns away or wears headphones with music.
+      </p>
+      
+      <h3 class="m-h3">Final preparation</h3>
+      
+      <p class="m-p">
+        Before starting the final, in game settings you must have selected and confirmed
+        <span class="m-strong">exactly 5 final questions</span>.
+        This ensures the final is ready to run without searching for questions during play.
+      </p>
+      
+      <p class="m-p">
+        In the final it is very important that the second contestant does not know the first contestant’s answers.
+        Therefore during the first contestant’s round the second contestant
+        <span class="m-strong">moves away and wears headphones with music</span>,
+        so they cannot hear the questions or answers.
+      </p>
+      
+      <h3 class="m-h3">Round 1 – first contestant (15 seconds)</h3>
+      
+      <p class="m-p">
+        The host reads five questions in a row, and the first contestant answers within
+        <span class="m-strong">15 seconds</span>.
+        The operator <span class="m-strong">types the answers</span> in the final panel.
+        At this stage answers are not yet scored or revealed.
+      </p>
+      
+      <p class="m-p">
+        After the round the operator assigns the typed answers to the list of scored results
+        and <span class="m-strong">reveals them on the board</span>.
+        If an answer does not match any item in the list,
+        it receives <span class="m-strong">0 points</span>.
+      </p>
+      
+      <p class="m-p">
+        After revealing the first contestant’s answers, the system hides their half of the board,
+        and the host prepares the entry of the second contestant and reminds the final rules.
+      </p>
+      
+      <h3 class="m-h3">Round 2 – second contestant (20 seconds) and repeats</h3>
+      
+      <p class="m-p">
+        The second contestant returns and answers the same questions within
+        <span class="m-strong">20 seconds</span>.
+        When the half-board with the first contestant’s answers appears,
+        the second contestant <span class="m-strong">turns away</span>
+        so they cannot see them and be influenced.
+      </p>
+      
+      <p class="m-p">
+        The operator again first types all answers of the second contestant,
+        without revealing or scoring them “live.”
+        If the second person gives the same answer as the first,
+        it is a <span class="m-strong">repeat</span> — the contestant must give another answer,
+        and the operator can mark the attempt as repeated.
+        Repeated answers do not score points.
+      </p>
+      
+      <p class="m-p">
+        After the round the operator assigns the second contestant’s answers to the list of scored results
+        and <span class="m-strong">reveals them one by one</span> on the board.
+        The points of both contestants are summed.
+      </p>
+      
+      <h3 class="m-h3">When the final ends</h3>
+      
+      <p class="m-p">
+        The final ends when the total points reach or exceed
+        the set threshold. It can happen that the threshold is reached after the first contestant’s turn
+        — then the second contestant does not need to play, and the game goes straight to the ending.
+      </p>
+      
+      <p class="m-p">
+        After the final the system shows the ending screen according to the game ending settings:
+        <span class="m-strong">logo</span>, <span class="m-strong">points</span> or
+        <span class="m-strong">prize amount</span>.
+      </p>`,
+      demo: `<p class="m-p">
+        In this tab you can restore sample starter materials:
+        a question base, logos, and ready games of different categories and states.
+      </p>
+  
+      <p class="m-p">
+        This is useful when:
+      </p>
+  
+      <ul class="m-ul">
+        <li>you want to quickly see how the system works</li>
+        <li>you are testing features without creating your own data</li>
+        <li>you accidentally removed the sample content</li>
+      </ul>
+  
+      <div class="m-warn">
+        Restoring demo does not remove your data — it only adds sample materials.
+      </div>
+  
+      <div class="m-box">
+        <button class="btn" id="demoRestoreBtn">
+          ↺ Restore demo files
+        </button>
+  
+        <p class="m-p m-muted" style="margin-top:10px">
+          After clicking you will be taken to the My games view and demo will be loaded automatically.
+        </p>
+      </div>`,
+    },
   },
   builderImportExport: {
     defaults: {

--- a/translation/pl.js
+++ b/translation/pl.js
@@ -782,6 +782,1322 @@ const pl = {
       modalOk: "Przywróć",
       modalCancel: "Anuluj",
     },
+    content: {
+      general: `<p class="m-p">
+        Ta strona to wskazówki obsługi systemu do prowadzenia rozgrywki (turnieju)
+        w stylu „Familiada”. Jej celem jest wyjaśnienie, jak przygotować grę,
+        zebrać wyniki (sondaż) i bez problemu poprowadzić rozgrywkę na żywo
+        — nawet jeśli ktoś korzysta z systemu pierwszy raz.
+      </p>
+      
+      <p class="m-p">
+        Opis dotyczy narzędzia i sposobu jego użycia,
+        a nie „telewizyjnej produkcji”. System sprawdzi się na wydarzeniach,
+        imprezach firmowych, w szkole, na scenie albo po prostu w gronie znajomych
+        — wszędzie tam, gdzie chcesz mieć czytelną tablicę, punkty i płynny przebieg gry.
+      </p>
+      
+      <p class="m-p">
+        Rozgrywka jest zbudowana tak, aby w dużym stopniu odpowiadała oficjalnym zasadom Familiady
+        (rundy, bank, błędy X, przejęcia i finał), ale całość jest zaprojektowana jako
+        wygodny system do prowadzenia zabawy/turnieju, z jasnym podziałem ról:
+        <span class="m-strong">prowadzący prowadzi rozmowę i zadaje pytania</span>,
+        a <span class="m-strong">operator steruje tablicą i punktami</span>.
+      </p>
+
+      <p class="m-p">
+        Jeśli chcesz zapoznać się z pełnymi zasadami gry,
+        <a href="https://s.tvp.pl/repository/attachment/6/8/f/68f09c03ff0781fa510c2fd90c3ba19b1569224834470.pdf"
+           target="_blank"
+           rel="noopener">
+          Regulamin teleturnieju „Familiada”
+        </a>
+        opisuje je szczegółowo.
+      </p>
+
+      <p class="m-p">
+        Całość systemu została zaprojektowana tak,
+        aby wyraźnie oddzielić przygotowanie treści
+        od samej rozgrywki.
+        Pytania, odpowiedzi i sondaże przygotowuje się wcześniej,
+        natomiast w trakcie gry operator korzysta wyłącznie
+        z panelu sterowania.
+      </p>
+
+      <p class="m-p">
+        W praktyce oznacza to, że w dniu nagrania
+        operator nie musi edytować danych,
+        prowadzący skupia się na rozmowie z uczestnikami,
+        a system pilnuje kolejności etapów i logiki rozgrywki.
+        Zmniejsza to ryzyko pomyłek i przyspiesza przebieg gry.
+      </p>
+
+      <p class="m-p">
+        System najlepiej działa przy użyciu osobnych urządzeń:
+        wyświetlacza dla widzów (telewizor lub rzutnik),
+        tabletu lub telefonu dla prowadzącego,
+        osobnego urządzenia pełniącego rolę przycisku
+        oraz komputera operatora z panelem sterowania.
+      </p>
+
+      <p class="m-p">
+        Wskarówki zostały podzielone na kolejne zakładki.
+        Każda z nich opisuje inny etap pracy z systemem:
+        od przygotowania gry,
+        przez sondaże,
+        aż po prowadzenie rozgrywki na żywo.
+      </p>`,
+      edit: `<p class="m-p">
+        Zakładka „Dodawanie i edycja gry” opisuje etap przygotowania gry
+        przed rozpoczęciem sondażu lub rozgrywki.
+        Na tym etapie tworzysz strukturę gry:
+        pytania, możliwe odpowiedzi oraz sposób ich punktowania.
+      </p>
+    
+      <p class="m-p">
+        Ten etap jest kluczowy, ponieważ decyduje o tym,
+        jak będzie wyglądać cała dalsza praca z grą.
+        System celowo rozdziela przygotowanie treści
+        od późniejszego zbierania odpowiedzi i prowadzenia rozgrywki.
+      </p>
+    
+      <h3 class="m-h2">Lista gier („Moje gry”)</h3>
+    
+      <p class="m-p">
+        Lista gier jest miejscem, w którym zarządzasz wszystkimi grami
+        przypisanymi do Twojego konta.
+        To tutaj możesz tworzyć nowe gry,
+        wybierać istniejące
+        oraz decydować, co chcesz z daną grą zrobić dalej.
+      </p>
+    
+      <p class="m-p">
+        Gry są podzielone na typy.
+        Typ gry określa, w jaki sposób odpowiedzi będą zbierane
+        i jak powstaną punkty widoczne później na tablicy.
+      </p>
+    
+      <ul class="m-ul">
+        <li>
+          <span class="m-strong">Typowy sondaż</span> —
+          odpowiedzi są wpisywane przez ankietowanych,
+          a punkty wynikają z liczby wskazań.
+        </li>
+        <li>
+          <span class="m-strong">Punktacja odpowiedzi</span> —
+          ankietowani wybierają spośród przygotowanych odpowiedzi,
+          a system zlicza głosy.
+        </li>
+        <li>
+          <span class="m-strong">Preparowany</span> —
+          odpowiedzi i punkty są ustalane ręcznie,
+          bez udziału sondażu.
+        </li>
+      </ul>
+    
+      <p class="m-p">
+        Nową grę tworzysz klikając kafelek z symbolem „＋”.
+        Po utworzeniu gra pojawia się na liście
+        i może zostać otwarta w edytorze.
+      </p>
+    
+      <h3 class="m-h2">Edytor gry – co i kiedy można edytować</h3>
+    
+     <p class="m-p">
+        Do trybu edycji gry przechodzisz z listy „Moje gry”
+        za pomocą przycisku <span class="m-code">Edytuj</span>.
+        Jest to pierwszy etap pracy z grą,
+        w którym przygotowujesz całą jej treść
+        przed wykorzystaniem jej w sondażu lub rozgrywce.
+      </p>
+      
+      <p class="m-p">
+        W trybie edycji tworzysz pytania i odpowiedzi,
+        decydujesz o typie gry
+        oraz przygotowujesz strukturę,
+        która będzie później wykorzystywana
+        do zbierania danych lub prowadzenia gry na żywo.
+      </p>
+      
+      <p class="m-p">
+        Edytor gry służy do budowania struktury pytań i odpowiedzi.
+        W zależności od typu gry oraz jej stanu
+        dostępne opcje edycji mogą się różnić.
+      </p>
+    
+      <p class="m-p">
+        Jest to działanie celowe.
+        System ogranicza pewne operacje,
+        aby zachować spójność danych
+        i zapobiec sytuacjom,
+        w których rozgrywka lub sondaż
+        przestają odpowiadać przygotowanej treści.
+      </p>
+    
+      <h3 class="m-h3">Dodawanie i edycja pytań</h3>
+    
+      <p class="m-p">
+        Pytania są zawsze podstawowym elementem gry.
+        Na etapie przygotowania możesz:
+        dodawać nowe pytania,
+        zmieniać ich treść
+        oraz usuwać pytania niepotrzebne.
+      </p>
+    
+      <p class="m-p">
+        Zmiana pytania po uruchomieniu sondażu
+        może zostać zablokowana,
+        ponieważ nawet drobna modyfikacja treści
+        wpływa na sens zebranych odpowiedzi.
+      </p>
+    
+      <h3 class="m-h3">Dodawanie i edycja odpowiedzi</h3>
+    
+      <p class="m-p">
+        Możliwość edycji odpowiedzi zależy od typu gry.
+        W grach sondażowych odpowiedzi są efektem ankiety,
+        dlatego przed sondażem możesz jedynie przygotować
+        ich ogólną strukturę lub przykłady.
+      </p>
+    
+      <p class="m-p">
+        Po rozpoczęciu sondażu system może ograniczyć
+        dodawanie lub usuwanie odpowiedzi,
+        aby nie mieszać odpowiedzi ankietowanych
+        z nową treścią.
+      </p>
+    
+      <h3 class="m-h3">Punkty – dlaczego czasem są zablokowane</h3>
+    
+      <p class="m-p">
+        Punkty nie zawsze są edytowalne ręcznie.
+        W grach sondażowych punkty wynikają bezpośrednio
+        z liczby udzielonych odpowiedzi,
+        dlatego ich ręczna edycja nie ma sensu
+        i jest zablokowana.
+      </p>
+    
+      <p class="m-p">
+        Ręczne ustawianie punktów jest możliwe
+        tylko w trybie preparowanym,
+        gdzie system nie korzysta z danych ankietowych.
+      </p>
+    
+      <div class="m-note">
+        <b>Dlaczego tak jest?</b><br/>
+        Dzięki temu to, co widzi widz na tablicy,
+        zawsze odpowiada rzeczywistym wynikom sondażu
+        albo jasno określonej, ręcznej punktacji.
+      </div>
+    
+      <h3 class="m-h2">Ograniczenia długości i formatu</h3>
+    
+      <p class="m-p">
+        Odpowiedzi powinny być krótkie i czytelne.
+        Przy imporcie treści odpowiedzi dłuższe
+        niż <span class="m-strong">17 znaków</span>
+        są automatycznie przycinane.
+      </p>
+    
+      <p class="m-p">
+        To ograniczenie wynika z układu tablicy
+        i ma na celu zachowanie czytelności
+        podczas rozgrywki na żywo.
+      </p>
+    
+      <h3 class="m-h2">Import i eksport gier</h3>
+    
+      <p class="m-p">
+        Builder umożliwia eksport i import gier
+        w postaci plików oraz bezpośrednio do bazy pytań.
+        Funkcja ta służy do przenoszenia gier i pytań
+        pomiędzy kontami lub środowiskami.
+      </p>
+    
+      <p class="m-p">
+        Pliki importu i eksportu są formatem technicznym.
+        Gra nie powinna ingerować w ich zawartość
+        ani próbować edytować ich ręcznie.
+      </p>
+    
+      <div class="m-warn">
+        <b>Uwaga:</b>
+        ręczna modyfikacja plików importu lub eksportu
+        może spowodować, że gry nie będzie się dało zaimportować
+        albo będzie działała nieprawidłowo.
+      </div>
+    
+      <p class="m-p">
+        Po poprawnym imporcie gra pojawia się
+        na liście gier i może być dalej edytowana
+        wyłącznie przy użyciu edytora systemowego.
+      </p>
+      
+      <p class="m-p">
+        Podczas eksportu gry do bazy:
+      </p>
+      
+      <ul class="m-ul">
+        <li>w katalogu głównym bazy tworzony jest nowy folder</li>
+        <li>folder otrzymuje nazwę gry</li>
+        <li>w folderze zapisywane są wszystkie pytania należące do gry</li>
+      </ul>
+
+      <p class="m-note">
+        Eksportować możesz tylko do swojej własnej bazy lub do udostępnionej bazy której jesteś edytorem.
+        Jeśli nie posiadasz aktualnie żadnych baz, nie będziesz mógł eksportować.
+      </p>
+      
+      <p class="m-p">
+        Dzięki temu każda gra może zostać zamieniona w zestaw pytań do dalszej edycji,
+        organizowania w folderach, oznaczania tagami oraz ponownego wykorzystania
+        w kolejnych grach.
+      </p>
+      
+      <p class="m-note">
+        Eksport do bazy nie usuwa gry — tworzy jedynie jej kopię w postaci struktury pytań.
+      </p>`,
+      bases: `<h2 class="m-h2">Bazy pytań — organizacja i współpraca</h2>
+  
+      <p class="m-p">
+        Bazy pytań to centralne miejsce przechowywania wszystkich pytań używanych w grach.
+        Dzięki nim możesz porządkować pytania w folderach, oznaczać je tagami, przypisywać do kategorii
+        oraz współdzielić całe bazy z innymi użytkownikami.
+      </p>
+      <p class="m-p">
+        Do baz pytań przechodzisz z górnego panelu strony „Moje gry”
+        za pomocą przycisku <span class="m-code">Bazy pytań 🗃️</span>.
+      </p>
+  
+      <p class="m-p">
+        Jedna baza może zawierać setki lub tysiące pytań uporządkowanych w strukturze podobnej
+        do klasycznego menadżera plików na komputerze.
+      </p>
+  
+      <h3 class="m-h3">➕ Dodawanie nowej bazy</h3>
+  
+      <p class="m-p">
+        W widoku „Bazy pytań” kliknij kafelek <span class="m-strong">Nowa baza</span>.
+        Otworzy się okno, w którym podajesz nazwę bazy.
+      </p>
+  
+      <p class="m-p">
+        Po zapisaniu nowa baza pojawi się na liście i od razu możesz ją przeglądać lub udostępniać.
+      </p>
+  
+      <h3 class="m-h3">🤝 Udostępnianie bazy</h3>
+  
+      <p class="m-p">
+        Każdą bazę możesz udostępnić innym użytkownikom poprzez podanie ich adresu e-mail.
+        Dostępne są dwa tryby:
+      </p>
+  
+      <ul class="m-ul">
+        <li><span class="m-strong">Edycja</span> — użytkownik może dodawać, usuwać i modyfikować pytania, foldery, tagi, tworzyć gry z pytań i eksportować pytania do bazy</li>
+        <li><span class="m-strong">Przeglądanie</span> — użytkownik może tylko przeglądać zawartość bazy i tworzyć gry z dostępnych pytań</li>
+      </ul>
+  
+      <p class="m-p">
+        Tylko właściciel bazy może zarządzać udostępnieniami.
+      </p>
+  
+      <h3 class="m-h3">📂 Przechodzenie do menadżera bazy</h3>
+  
+      <p class="m-p">
+        Aby wejść do zawartości bazy, zaznacz ją na liście i kliknij przycisk <span class="m-code">Przeglądaj</span>.
+      </p>
+  
+      <p class="m-p">
+        Otworzy się Base Explorer — zaawansowany menadżer pytań działający jak klasyczny eksplorator plików.
+      </p>
+  
+      <h2 class="m-h2">Base Explorer — menadżer pytań</h2>
+  
+      <p class="m-p">
+        Base Explorer pozwala zarządzać pytaniami w sposób znany z systemowych menadżerów plików:
+        foldery, przenoszenie metodą „przeciągnij i upuść”, kopiowanie, wycinanie i szybka selekcja.
+      </p>
+  
+      <p class="m-p">
+        Każdy „plik” w tym menadżerze jest pojedynczym pytaniem.
+        Foldery służą do grupowania pytań tematycznie lub logicznie.
+      </p>
+  
+      <p class="m-p">
+        Możesz:
+      </p>
+  
+      <ul class="m-ul">
+        <li>tworzyć dowolnie zagnieżdżone foldery</li>
+        <li>przenosić pytania i foldery między sobą</li>
+        <li>kopiować i duplikować elementy</li>
+        <li>usuwać zaznaczone pozycje</li>
+        <li>wyszukiwać po nazwie i tagach</li>
+      </ul>
+  
+      <p class="m-note">
+        Interfejs i skróty klawiszowe działają podobnie jak w klasycznych menadżerach plików
+        (Explorer, Finder, Total Commander).
+      </p>
+  
+      <h2 class="m-h2">Tagi i kategorie</h2>
+  
+      <h3 class="m-h3">🏷️ Tagi</h3>
+  
+      <p class="m-p">
+        Każde pytanie może mieć dowolną liczbę tagów.
+        Tagi służą do tematycznego oznaczania pytań — np. „historia”, „sport”, „łatwe”, „dla dzieci”.
+      </p>
+  
+      <p class="m-p">
+        Możesz:
+      </p>
+  
+      <ul class="m-ul">
+        <li>tworzyć własne tagi z kolorami</li>
+        <li>przypisywać wiele tagów do jednego pytania</li>
+        <li>filtrować widok po wybranych tagach</li>
+      </ul>
+
+      <p class="m-p">
+        Przypisywanie tagów odbywa się w specjalnym oknie, które można otworzyć z paska narzędzi
+        lub z menu kontekstowego.
+      </p>
+      
+      <p class="m-p">
+        W oknie przypisywania tagów widoczna jest lista wszystkich dostępnych tagów wraz z ich stanem:
+      </p>
+      
+      <ul class="m-ul">
+        <li>zaznaczony — tag jest przypisany do wszystkich wybranych elementów</li>
+        <li>niezaznaczony — tag nie jest przypisany do żadnego z nich</li>
+        <li>częściowy — tylko część zaznaczenia posiada dany tag</li>
+      </ul>
+      
+      <p class="m-p">
+        Kliknięcie w tag przełącza jego stan cyklicznie, umożliwiając szybkie dodawanie i usuwanie tagów
+        dla wielu pytań lub folderów jednocześnie. To okno umożliwia tworzenie nowych tagów.
+      </p>
+      
+      <p class="m-p">
+        Tagi mogą być również używane jako filtry — kliknięcie taga po lewej stronie ogranicza widok
+        do elementów oznaczonych wybranym tagiem lub zestawem tagów.
+      </p>
+  
+      <p class="m-note">
+        Folder pokazuje znaczniki tagów wtedy, gdy wszystkie znajdujące się w nim pytania
+        (oraz podfoldery) posiadają ten sam tag.
+      </p>
+  
+      <h3 class="m-h3">📌 Kategorie</h3>
+  
+      <p class="m-p">
+        Kategorie to specjalne oznaczenia systemowe określające,
+        do jakiego typu gry dane pytanie pasuje. Co odpowiada typom gier w widoku <span class="m-strong">Moje gry</span></li>
+      </p>
+  
+      <p class="m-p">
+        Przykładowo:
+      </p>
+  
+      <ul class="m-ul">
+        <li>pytania z odpowiedziami i punktami trafiają do kategorii <span class="m-strong">preperowane</span></li>
+        <li>pytania z odpowiedziami bez sumy punktów do <span class="m-strong">punktacja</span></li>
+        <li>pytania tekstowe bez punktów do <span class="m-strong">typowe</span></li>
+      </ul>
+  
+      <p class="m-p">
+        Kategorie są przypisywane automatycznie na podstawie struktury pytania,
+        a nie ręcznie przez użytkownika.
+      </p>
+  
+      <p class="m-note">
+        Dzięki temu od razu wiesz, które pytania nadają się do konkretnego typu gry.
+      </p>
+  
+      <h2 class="m-h2">Edytor pytań</h2>
+  
+      <p class="m-p">
+        Każde pytanie możesz otworzyć w edytorze.
+        Edytor pozwala zmieniać treść pytania, odpowiedzi oraz punkty (jeśli występują).
+      </p>
+  
+      <p class="m-p">
+        System pilnuje podstawowych zasad, takich jak:
+      </p>
+  
+      <ul class="m-ul">
+        <li>maksymalna liczba punktów dla jednej odpowiedzi</li>
+        <li>łączna suma punktów w pytaniu</li>
+      </ul>
+  
+      <p class="m-p">
+        Dzięki temu baza zawsze pozostaje spójna i gotowa do użycia w grach.
+      </p>
+  
+      <h2 class="m-h2">Tworzenie gry z pytań</h2>
+  
+      <p class="m-p">
+        W Menadżerze bazy możesz zaznaczyć dowolne pytania oraz foldery (wraz z podfolderami),
+        a następnie utworzyć z nich nową grę.
+      </p>
+  
+      <p class="m-p">
+        System zbiera wszystkie pytania z zaznaczenia, pozwala je przejrzeć
+        i wybrać typ gry.
+      </p>
+
+      <p class="m-note">
+        To umożliwia szybkie budowanie gier z gotowych zestawów pytań bez ręcznego przepisywania.
+      </p>
+
+      <p class="m-warn">
+        Po pomyślnym utworzeniu gry zostaniesz przekierowany do widoku <span class="m-strong">Moje gry</span></li>
+      </p>
+  
+      <h2 class="m-h2">⌨️ Skróty klawiszowe — Menadżer bazy</h2>
+  
+      <h3 class="m-h3">📁 Tworzenie</h3>
+  
+      <table class="m-table">
+        <tr><th>Akcja</th><th>Windows / Linux</th><th>macOS</th></tr>
+        <tr><td>Nowe pytanie</td><td>Ctrl + N</td><td>⌘ N</td></tr>
+        <tr><td>Nowy folder</td><td>Ctrl + Shift + N</td><td>⌘ ⇧ N</td></tr>
+      </table>
+  
+      <h3 class="m-h3">✏️ Edycja</h3>
+  
+      <table class="m-table">
+        <tr><th>Akcja</th><th>Windows / Linux</th><th>macOS</th></tr>
+        <tr><td>Edytuj pytanie</td><td>Ctrl + E</td><td>⌘ E</td></tr>
+        <tr><td>Zmień nazwę</td><td>F2</td><td>F2</td></tr>
+        <tr><td>Usuń</td><td>Delete</td><td>Fn + ⌫</td></tr>
+      </table>
+  
+      <h3 class="m-h3">📋 Schowek</h3>
+  
+      <table class="m-table">
+        <tr><th>Akcja</th><th>Windows / Linux</th><th>macOS</th></tr>
+        <tr><td>Kopiuj</td><td>Ctrl + C</td><td>⌘ C</td></tr>
+        <tr><td>Wytnij</td><td>Ctrl + X</td><td>⌘ X</td></tr>
+        <tr><td>Wklej</td><td>Ctrl + V</td><td>⌘ V</td></tr>
+        <tr><td>Duplikuj</td><td>Ctrl + D</td><td>⌘ D</td></tr>
+      </table>
+  
+      <h3 class="m-h3">🎮 Gra</h3>
+  
+      <table class="m-table">
+        <tr><th>Akcja</th><th>Windows / Linux</th><th>macOS</th></tr>
+        <tr><td>Utwórz grę</td><td>Ctrl + G</td><td>⌘ G</td></tr>
+      </table>
+  
+      <h3 class="m-h3">🔄 Widok</h3>
+  
+      <table class="m-table">
+        <tr><th>Akcja</th><th>Windows / Linux</th><th>macOS</th></tr>
+        <tr><td>Odśwież widok</td><td>Ctrl + Alt + R</td><td>⌘ ⌥ R</td></tr>
+      </table>
+  
+      <h3 class="m-h3">📌 Nawigacja</h3>
+  
+      <table class="m-table">
+        <tr><th>Akcja</th><th>Windows / Linux</th><th>macOS</th></tr>
+        <tr><td>Zaznacz wszystko</td><td>Ctrl + A</td><td>⌘ A</td></tr>
+        <tr><td>Otwórz folder</td><td>Enter</td><td>⏎</td></tr>
+        <tr><td>Folder nadrzędny</td><td>Backspace</td><td>⌫</td></tr>
+      </table>
+  
+      <p class="m-note">
+        Skróty nie działają podczas wpisywania tekstu w polach edycyjnych.
+      </p>`,
+      polls: `<p class="m-p">
+        Zakładka „Sondaże” opisuje etap zbierania odpowiedzi
+        od ankietowanych przed właściwą rozgrywką.
+        Sondaż jest mostem pomiędzy przygotowaniem gry
+        a jej rozegraniem na żywo.
+      </p>
+    
+      <p class="m-p">
+        Na tym etapie system przestaje być edytorem treści,
+        a zaczyna działać jak narzędzie do zbierania danych.
+        Z tego powodu wiele opcji edycji jest celowo ograniczonych.
+      </p>
+
+      <p class="m-p">
+        Do sondaży przechodzisz z listy „Moje gry”
+        za pomocą przycisku <span class="m-code">Centrum Sondaży</span>.
+        Ten etap następuje po zakończeniu edycji gry
+        i służy wyłącznie do zbierania odpowiedzi
+        lub głosów od ankietowanych.
+      </p>
+      
+      <p class="m-p">
+        W momencie uruchomienia sondażu
+        gra przestaje być edytowalna
+        i zaczyna pełnić rolę narzędzia do zbierania danych.
+        Z tego powodu część opcji dostępnych w edytorze
+        jest w tym trybie celowo zablokowana.
+      </p>
+
+      <h3 class="m-h2">Centrum sondaży (polls-hub)</h3>
+
+      <p class="m-p">
+        Centrum sondaży to osobny panel zarządzania sondażami, zadaniami i subskrypcjami.
+        Otwierasz go z listy „Moje gry” przyciskiem <span class="m-code">Centrum Sondaży</span>.
+        Na komputerze widzisz dwie karty, a w każdej dwie listy.
+      </p>
+
+      <ul class="m-ul">
+        <li><span class="m-strong">Sondaże</span> — lista „Moje sondaże” oraz „Zadania”.</li>
+        <li><span class="m-strong">Subskrypcje</span> — lista „Moi subskrybenci” oraz „Moje subskrypcje”.</li>
+      </ul>
+
+      <p class="m-p">
+        Złota kropka na karcie „Sondaże” pokazuje liczbę aktywnych zadań do wykonania,
+        a na karcie „Subskrypcje” liczbę zaproszeń do zaakceptowania.
+      </p>
+
+      <p class="m-p">
+        Subskrypcja to stałe połączenie między Twoim kontem a zaproszonym użytkownikiem —
+        raz zaakceptowana pozwala udostępniać kolejne sondaże bez wpisywania e-maila od nowa.
+        Zaproszenie wysyłasz w sekcji „Moi subskrybenci”, wpisując e-mail lub nazwę użytkownika
+        i klikając <span class="m-code">Zaproś</span>. Odbiorca akceptuje zaproszenie w swoim
+        Centrum Sondaży lub z linku w wiadomości, a status zmienia się na aktywny.
+      </p>
+
+      <p class="m-p">
+        Udostępnianie sondażu odbywa się z listy „Moje sondaże”: zaznacz kafelek i kliknij
+        <span class="m-code">Udostępnij</span>, następnie wybierz subskrybentów i zapisz.
+        Kafelek sondażu pokazuje bieżące głosy, a przycisk <span class="m-code">Szczegóły</span>
+        daje podgląd listy oddanych głosów, oczekujących, odrzuconych oraz anonimowych odpowiedzi.
+      </p>
+
+      <h3 class="m-h3">Moje sondaże</h3>
+      <p class="m-p">
+        Każdy kafelek ma kolor, który oznacza stan sondażu:
+      </p>
+      <ul class="m-ul">
+        <li><span class="m-strong">Szary</span> — szkic, brakuje wymagań do uruchomienia.</li>
+        <li><span class="m-strong">Czerwony</span> — szkic gotowy do uruchomienia.</li>
+        <li><span class="m-strong">Pomarańczowy</span> — sondaż otwarty, brak głosów.</li>
+        <li><span class="m-strong">Żółty</span> — sondaż otwarty, są głosy lub aktywne zadania.</li>
+        <li><span class="m-strong">Zielony</span> — sondaż otwarty, cele zebrane (zadania wykonane lub ≥10 głosów).</li>
+        <li><span class="m-strong">Niebieski</span> — sondaż zamknięty.</li>
+      </ul>
+
+      <h3 class="m-h3">Zadania</h3>
+      <p class="m-p">
+        Zadania to zaproszenia do głosowania. Kolory:
+        <span class="m-strong">zielony</span> — dostępne,
+        <span class="m-strong">niebieski</span> — wykonane.
+        Dwuklik otwiera głosowanie, a przycisk <span class="m-code">X</span> odrzuca zadanie.
+      </p>
+
+      <h3 class="m-h3">Moi subskrybenci</h3>
+      <p class="m-p">
+        Kolory statusów:
+        <span class="m-strong">żółty</span> — oczekujące,
+        <span class="m-strong">zielony</span> — aktywne,
+        <span class="m-strong">czerwony</span> — odrzucone/anulowane.
+        Przyciski <span class="m-code">X</span> usuwa subskrybenta, a <span class="m-code">↻</span> ponawia zaproszenie.
+      </p>
+
+      <h3 class="m-h3">Moje subskrypcje</h3>
+      <p class="m-p">
+        Kolory:
+        <span class="m-strong">żółty</span> — oczekujące,
+        <span class="m-strong">zielony</span> — aktywne.
+        Przyciski: <span class="m-code">✓</span> akceptuje, <span class="m-code">X</span> odrzuca/anuluje.
+      </p>
+
+    
+      <h3 class="m-h2">Rodzaje sondaży</h3>
+    
+      <p class="m-p">
+        W zależności od typu gry sondaż może działać w jednym z dwóch trybów:
+      </p>
+    
+      <ul class="m-ul">
+        <li>
+          <span class="m-strong">Typowy sondaż (tekstowy)</span> —
+          ankietowani wpisują własne odpowiedzi tekstowe.
+        </li>
+        <li>
+          <span class="m-strong">Sondaż punktacji</span> —
+          ankietowani wybierają jedną z przygotowanych odpowiedzi.
+        </li>
+      </ul>
+    
+      <p class="m-p">
+        Gry preparowane nie posiadają sondażu —
+        odpowiedzi i punkty są w nich ustalane ręcznie.
+      </p>
+    
+      <h3 class="m-h2">Uruchamianie sondażu</h3>
+    
+      <p class="m-p">
+        Sondaż można uruchomić wyłącznie dla gry
+        znajdującej się w stanie <span class="m-strong">Szkic</span>.
+        Przed uruchomieniem system sprawdza,
+        czy gra spełnia minimalne wymagania.
+      </p>
+    
+      <ul class="m-ul">
+        <li>minimalna liczba pytań,</li>
+        <li>w trybie punktacji — odpowiednia liczba odpowiedzi przy każdym pytaniu.</li>
+      </ul>
+    
+      <div class="m-note">
+        <b>Dlaczego?</b><br/>
+        Dzięki temu nie da się uruchomić sondażu,
+        który nie może zostać później poprawnie zamknięty
+        i użyty w rozgrywce.
+      </div>
+    
+      <h3 class="m-h2">Link i kod QR</h3>
+    
+      <p class="m-p">
+        Po uruchomieniu sondażu system generuje
+        unikalny link do głosowania.
+        Link ten można skopiować,
+        otworzyć w nowej karcie
+        lub wyświetlić jako kod QR.
+      </p>
+    
+      <p class="m-p">
+        Kod QR jest przeznaczony do wyświetlania
+        na ekranie widocznym dla ankietowanych
+        (telewizor, rzutnik, duży monitor).
+      </p>
+    
+      <h3 class="m-h2">Przebieg sondażu</h3>
+    
+      <p class="m-p">
+        Ankietowani przechodzą przez pytania po kolei.
+        System pilnuje kolejności
+        i nie pozwala pominąć pytania.
+      </p>
+    
+      <p class="m-p">
+        W sondażu tekstowym każda odpowiedź:
+      </p>
+    
+      <ul class="m-ul">
+        <li>jest ograniczona do 17 znaków,</li>
+        <li>jest normalizowana (wielkość liter, spacje),</li>
+        <li>zliczana jest jako osobna propozycja.</li>
+      </ul>
+    
+      <p class="m-p">
+        W sondażu punktacji ankietowany
+        wybiera jedną z przygotowanych odpowiedzi,
+        a system zapisuje oddany głos.
+      </p>
+    
+      <h3 class="m-h2">Zamykanie sondażu</h3>
+    
+      <p class="m-p">
+        Zamknięcie sondażu jest osobnym,
+        świadomym etapem pracy.
+        System nie pozwala zamknąć sondażu,
+        jeśli zebrane dane nie spełniają
+        minimalnych warunków jakości.
+      </p>
+    
+      <h3 class="m-h3">Sondaż punktacji</h3>
+    
+      <p class="m-p">
+        Przy zamykaniu sondażu punktacji
+        system przelicza głosy na punkty
+        i normalizuje je do skali 0–100
+        dla każdego pytania.
+      </p>
+    
+      <div class="m-note">
+        <b>Efekt:</b>
+        otrzymujesz gotową listę odpowiedzi z punktami,
+        bez potrzeby ręcznego liczenia.
+      </div>
+    
+      <h3 class="m-h3">Sondaż tekstowy</h3>
+    
+      <p class="m-p">
+        W sondażu tekstowym (klasycznym) ankietowani wpisują własne odpowiedzi.
+        Po zamknięciu sondażu system przechodzi do etapu porządkowania wyników.
+        Operator może łączyć oczywiście podobne odpowiedzi
+        oraz usuwać literówki lub oczywiste duplikaty.
+      </p>
+      
+      <p class="m-p">
+        Następnie odpowiedzi są normalizowane do skali punktowej.
+        Na tym etapie system stosuje dodatkowe ograniczenia,
+        które mają na celu zachowanie czytelności tablicy
+        i dynamiki rozgrywki.
+      </p>
+      
+      <p class="m-p">
+        Odpowiedzi o bardzo małej liczbie wskazań,
+        które po normalizacji uzyskują
+        <span class="m-strong">mniej niż 8 punktów</span>,
+        są automatycznie odrzucane.
+        Takie odpowiedzi zwykle nie mają znaczenia dla gry
+        i nie byłyby czytelne dla widzów.
+      </p>
+      
+      <p class="m-p">
+        Dla jednego pytania na tablicy
+        może znaleźć się maksymalnie
+        <span class="m-strong">6 odpowiedzi</span>.
+        Jeżeli poprawnych odpowiedzi jest więcej,
+        system wybiera te najlepiej punktowane,
+        a pozostałe są pomijane.
+      </p>
+      
+      <p class="m-p">
+        Z tego powodu suma punktów dla jednego pytania
+        <span class="m-strong">nie zawsze wynosi dokładnie 100</span>.
+        Punkty przypisane są wyłącznie do odpowiedzi,
+        które faktycznie trafiają na tablicę.
+      </p>
+    
+      <div class="m-warn">
+        <b>Uwaga:</b>
+        po zamknięciu sondażu
+        nie można już zmieniać jego wyników
+        bez ponownego uruchomienia sondażu.
+      </div>
+    
+      <h3 class="m-h2">Ponowne uruchomienie sondażu</h3>
+    
+      <p class="m-p">
+        Zamknięty sondaż można uruchomić ponownie,
+        co powoduje usunięcie poprzednich wyników
+        i rozpoczęcie zbierania odpowiedzi od nowa.
+      </p>
+    
+      <p class="m-p">
+        Ta opcja jest przydatna,
+        gdy sondaż został uruchomiony testowo
+        lub doszło do błędu organizacyjnego.
+      </p>`,
+      logo: `<p class="m-p">
+      System pozwala ustawić własne logo, które pojawia się na wyświetlaczu
+      (np. na ekranie startowym lub zakończenia). Do tworzenia logo przechodzisz z górnego panelu strony „Moje gry”
+        za pomocą przycisku <span class="m-code">Logo🖥️</span>.
+    </p>
+
+    <div class="m-note">
+      <b>Ważne:</b><br/>
+      Logo ma rozmiar techniczny <span class="m-code">30×10</span> (kafelki znaków) albo <span class="m-code">150×70</span> (piksele).
+      To ograniczenie wynika z fizycznego układu tablicy i ma zapewnić czytelność na żywo.
+    </div>
+
+    <h3 class="m-h2">Tryby tworzenia logo</h3>
+
+    <p class="m-p">
+      Podczas tworzenia nowego logo wybierasz jeden z trybów.
+      Każdy tryb prowadzi do tego samego efektu (logo na wyświetlaczu),
+      ale różni się sposobem tworzenia.
+    </p>
+
+    <ul class="m-ul">
+      <li>
+        <span class="m-strong">Napis</span> — klasyczne logo złożone ze znaków (styl „Familiady”).
+        Dobre, gdy chcesz szybko zrobić czytelny tytuł.
+      </li>
+      <li>
+        <span class="m-strong">Tekst</span> — edycja tekstu i podgląd w „pikselach”.
+        Dobre, gdy potrzebujesz innego kroju/układu niż w „Napis”.
+      </li>
+      <li>
+        <span class="m-strong">Rysunek</span> — rysujesz ręcznie w siatce (jak w prostym edytorze grafiki).
+        Dobre do ikon i prostych kształtów.
+      </li>
+      <li>
+        <span class="m-strong">Obraz</span> — importujesz obrazek i dopasowujesz go do tablicy.
+        Dobre, gdy masz gotowe logo firmy.
+      </li>
+    </ul>
+
+    <h3 class="m-h2">Podgląd na wyświetlaczu</h3>
+
+    <p class="m-p">
+      W edytorze cały czas widzisz podgląd „jak na tablicy”.
+      To ważne, bo to co wygląda dobrze w dużej rozdzielczości,
+      może być nieczytelne po sprowadzeniu do <span class="m-code">150×70</span>.
+    </p>
+
+    <div class="m-note">
+      <b>Praktyczna rada:</b><br/>
+      Najlepiej sprawdzają się grube kształty, duże litery i wysoki kontrast.
+      Cienkie linie, małe detale i delikatne przejścia zwykle znikają.
+    </div>
+
+    <h3 class="m-h2">Zapis i aktywne logo</h3>
+
+    <p class="m-p">
+      Logo możesz zapisać pod własną nazwą. Na liście logotypów możesz też ustawić,
+      które logo jest <span class="m-strong">aktywne</span>.
+      Aktywne logo będzie używane przez wyświetlacz automatycznie.
+    </p>
+
+    <p class="m-p">
+      Jeśli nie ustawisz żadnego aktywnego logo, system użyje
+      <span class="m-strong">domyślnego logo</span>.
+    </p>
+
+    <h3 class="m-h2">Import i eksport logo</h3>
+
+    <p class="m-p">
+      Edytor pozwala eksportować aktywne logo do pliku oraz importować logo z pliku.
+      Dzięki temu możesz przenosić logo pomiędzy kontami lub robić kopie zapasowe.
+    </p>
+
+    <div class="m-warn">
+      <b>Uwaga:</b><br/>
+      Nie edytuj plików logo ręcznie. To format techniczny — ręczna zmiana może spowodować,
+      że import się nie powiedzie albo logo będzie działało nieprawidłowo.
+    </div>`,
+      control: `<p class="m-p">
+        Do Panelu sterowania przechodzisz z listy „Moje gry”
+        za pomocą przycisku <span class="m-code">Graj</span>.
+        Ten tryb jest przeznaczony wyłącznie do prowadzenia rozgrywki na żywo —
+        w tym miejscu nie edytujesz już pytań ani wyników sondażu.
+      </p>
+    
+      <p class="m-p">
+        Panel sterowania prowadzi operatora krok po kroku:
+        najpierw podłączasz urządzenia, potem ustawiasz parametry rozgrywki,
+        a na końcu przechodzisz przez rundy i (opcjonalnie) finał.
+        Kolejne kroki odblokowują się dopiero wtedy, gdy poprzednie są gotowe,
+        co minimalizuje ryzyko pomyłek podczas nagrania.
+      </p>
+    
+      <h3 class="m-h2">Co musi być gotowe, zanim zaczniesz</h3>
+    
+      <ul class="m-ul">
+        <li>
+          Gra powinna mieć przygotowane pytania i odpowiedzi (z edytora),
+          a jeśli jest to gra sondażowa — sondaż powinien być zakończony i zatwierdzony.
+        </li>
+        <li>
+          Operator powinien mieć komputer z dużym ekranem (panel jest projektowany pod tryb desktopowy).
+        </li>
+        <li>
+          Powinny być przygotowane osobne urządzenia: wyświetlacz (TV/rzutnik), urządzenie prowadzącego,
+          oraz urządzenie pełniące rolę przycisku.
+        </li>
+        <li>
+          Stabilne Wi-Fi (najczęstsza przyczyna problemów to ubite karty w tle / przełączanie sieci).
+        </li>
+      </ul>
+    
+      <div class="m-note">
+        <b>Dlaczego tyle „formalności”?</b><br/>
+        Rozgrywka jest na żywo i ma telewizyjne tempo. Panel sterowania ma pilnować procedury,
+        a nie dokładać operatorowi stresu. Dlatego system wymusza gotowość sprzętu i ustawień przed startem.
+      </div>
+    
+      <h3 class="m-h2">Kto co widzi</h3>
+    
+      <p class="m-p">
+        System celowo rozdziela ekrany, żeby każdy robił swoje:
+      </p>
+    
+      <ul class="m-ul">
+        <li>
+          <span class="m-strong">Operator (Panel sterowania)</span> — widzi wszystkie przyciski,
+          status gry, bank, X-y, komunikaty i kolejne kroki procedury.
+          Operator steruje tym, co pojawia się na tablicy.
+        </li>
+        <li>
+          <span class="m-strong">Wyświetlacz</span> — pokazuje tablicę gry: pytania, odpowiedzi,
+          punkty, bank, błędy (X) oraz ekrany startu i zakończenia.
+          To ekran widoczny dla uczestników i widowni.
+        </li>
+        <li>
+          <span class="m-strong">Prowadzący</span> — dostaje treści do odczytania i podgląd kontekstu,
+          ale nie steruje przebiegiem gry (steruje operator).
+        </li>
+        <li>
+          <span class="m-strong">Przycisk</span> — służy do sygnału w pojedynku (kto pierwszy).
+        </li>
+      </ul>
+    
+      <h3 class="m-h2">1) Urządzenia</h3>
+    
+      <p class="m-p">
+        Pierwszy etap w panelu to podłączenie urządzeń.
+        W górnym pasku panelu widzisz trzy statusy:
+        <span class="m-strong">Wyświetlacz</span>,
+        <span class="m-strong">Prowadzący</span>,
+        <span class="m-strong">Przycisk</span>.
+        Operator rozpoczyna od tego, żeby wszystkie były online.
+      </p>
+    
+      <h3 class="m-h3">Krok 1: Wyświetlacz</h3>
+    
+      <p class="m-p">
+        W tym kroku panel pokazuje kod QR i link dla wyświetlacza.
+        Najlepiej otworzyć wyświetlacz na telewizorze lub rzutniku,
+        w trybie pełnoekranowym (bez pasków przeglądarki).
+        Dopiero gdy wyświetlacz jest online, panel pozwoli przejść dalej.
+      </p>
+    
+      <h3 class="m-h3">Krok 2: Prowadzący i Przycisk</h3>
+    
+      <p class="m-p">
+        W drugim kroku podłączasz urządzenie prowadzącego i urządzenie przycisku.
+        Panel również pokazuje QR/link do podłączenia.
+        W praktyce najlepiej użyć dwóch osobnych telefonów albo telefonu i tabletu.
+      </p>
+    
+      <p class="m-p">
+        W tym kroku jest opcja <span class="m-strong">„QR na wyświetlaczu”</span> —
+        po jej użyciu kody QR mogą zostać pokazane na dużym ekranie,
+        żeby ekipa mogła szybko zeskanować je telefonami.
+        To przyspiesza start na planie, bo nie trzeba przepisywać linków.
+      </p>
+    
+      <div class="m-warn">
+        <b>Uwaga:</b><br/>
+        Jeśli któreś urządzenie rozłączy się w trakcie, panel potrafi pokazać ostrzeżenie.
+        Najczęściej pomaga: wyłączyć oszczędzanie baterii, nie minimalizować przeglądarki
+        oraz trzymać urządzenia na jednej stabilnej sieci Wi-Fi.
+      </div>
+    
+      <h3 class="m-h3">Krok 3: Dźwięk</h3>
+    
+      <p class="m-p">
+        Przeglądarki blokują automatyczne odtwarzanie dźwięku,
+        dopóki użytkownik nie wykona „gestu” (kliknięcia).
+        Dlatego panel ma osobny krok odblokowania dźwięku.
+        Bez tego możesz nie usłyszeć sygnałów, które wspierają tempo gry.
+      </p>
+    
+      <h3 class="m-h2">2) Ustawienia</h3>
+    
+      <p class="m-p">
+        Gdy urządzenia są online, przechodzisz do ustawień rozgrywki.
+        Ten etap ma dwa cele:
+        (1) przygotować czytelne nazwy drużyn na tablicy,
+        (2) dopasować parametry rozgrywki do nagrania (dodatkowe ustawienia).
+      </p>
+    
+      <h3 class="m-h3">Nazwy drużyn</h3>
+    
+      <p class="m-p">
+        Ustawiasz nazwę drużyny A i B.
+        Są to napisy, które widzą zawodnicy i widownia na wyświetlaczu,
+        więc najlepiej ustalić je przed startem rund.
+        Panel blokuje przejście dalej, dopóki obie nazwy nie są wpisane.
+      </p>
+    
+      <h3 class="m-h3">Dodatkowe ustawienia (ważne dla operatora)</h3>
+    
+      <p class="m-p">
+        W „Dodatkowych ustawieniach” dopasowujesz rozgrywkę do formatu odcinka.
+        Te opcje nie zmieniają sensu zasad, tylko ustawiają tempo i progi gry.
+      </p>
+    
+      <ul class="m-ul">
+        <li>
+          <span class="m-strong">Mnożniki rund</span> — wpisywane po przecinku (np. <span class="m-code">1,1,1,2,3</span>).
+          To odpowiada klasycznemu podwajaniu/potrajaniu wartości w kolejnych etapach.
+          W praktyce: bank rundy na końcu jest mnożony przez mnożnik bieżącej rundy.
+        </li>
+        <li>
+          <span class="m-strong">Cel rozgrywki</span> — próg punktów, po którym gra może przejść do finału
+          (w klasycznej formule często 300). To pozwala dopasować długość gry.
+        </li>
+        <li>
+          <span class="m-strong">Cel finału</span> — próg punktów w finale (domyślnie 200 w klasycznej formule).
+        </li>
+        <li>
+          <span class="m-strong">Zakończenie gry</span> — co pokazuje wyświetlacz na końcu
+          (logo / punkty / kwota po finale). To jest ważne produkcyjnie: „ostatni kadr”.
+        </li>
+      </ul>
+    
+      <div class="m-note">
+        <b>Dlaczego to jest w Panelu sterowania, a nie w edytorze?</b><br/>
+        Bo to są ustawienia odcinka (produkcji), a nie treści pytań.
+        Pytania nie powinny się zmieniać podczas rozgrywki, ale parametry gry czasem tak.
+      </div>
+    
+      <h3 class="m-h3">Finał: włącz i wybierz 5 pytań</h3>
+    
+      <p class="m-p">
+        Jeśli rozgrywka ma mieć finał, włączasz finał i wybierasz dokładnie <span class="m-strong">5 pytań finału</span>.
+        Panel pokazuje listę pytań oraz listę „Pytania finału (max 5)”.
+        Po wybraniu piątki używasz przycisku <span class="m-strong">Zatwierdź</span>.
+      </p>
+    
+      <div class="m-warn">
+        <b>Uwaga:</b><br/>
+        Finał wymaga zatwierdzonych 5 pytań przed startem rund.
+        To celowa blokada — na żywo nie ma czasu na wybieranie pytań „na szybko”.
+        Jeśli chcesz zmienić zestaw, używasz trybu <span class="m-strong">Edytuj</span> przy pytaniach finału.
+      </div>
+    
+      <h3 class="m-h2">3) Rundy — przebieg gry krok po kroku</h3>
+    
+      <p class="m-p">
+        W rundach prowadzisz właściwą rozgrywkę: pytania, odpowiedzi, punkty i bank rundy.
+        Gracze widzą tablicę na wyświetlaczu, prowadzący zadaje pytania i pilnuje przebiegu,
+        a operator odsłania odpowiedzi, nalicza punkty oraz dodaje błędy (X).
+      </p>
+      
+      <p class="m-p">
+        Najważniejsza zasada w praktyce: prowadzący skupia się na uczestnikach,
+        a operator na obsłudze systemu. Dzięki temu gra jest płynna,
+        a tablica zawsze pokazuje to, co powinno być w danym momencie.
+      </p>
+    
+      <h3 class="m-h3">Start rundy: „Gra gotowa” i intro</h3>
+    
+      <p class="m-p">
+        Rozpoczynając rundy, panel najpierw przygotowuje wyświetlacz (czyści tablicę i ustawia stan gry),
+        a następnie pozwala uruchomić intro.
+        To porządkuje początek nagrania: widzowie dostają czytelny start,
+        a operator ma jasny moment wejścia w pierwsze pytanie.
+      </p>
+    
+      <h3 class="m-h3">Pojedynek: kto przejmuje kontrolę</h3>
+    
+      <p class="m-p">
+        Każde pytanie zaczyna się od pojedynku „głów rodzin” przy pulpicie.
+        W tym momencie kluczowe jest urządzenie <span class="m-strong">Przycisk</span>:
+        sygnał z przycisku informuje panel, że ktoś nacisnął pierwszy.
+        Operator zatwierdza, która strona zdobyła pierwszeństwo,
+        a prowadzący przechodzi do udzielania odpowiedzi.
+      </p>
+    
+      <p class="m-p">
+        Zgodnie z regulaminem, jeśli pierwsza odpowiedź nie jest najwyżej punktowana,
+        druga „głowa” ma szansę odpowiedzieć lepiej i przejąć kontrolę.
+        Panel prowadzi operatora przez decyzję kontroli rundy,
+        a wyświetlacz pokazuje, która drużyna aktualnie gra (wskaźnik drużyny).
+      </p>
+
+      <h3 class="m-h3">Oddanie pytania</h3>
+    
+      <p class="m-p">
+        Zgodnie z ustaleniami rozgrywki, po uzyskaniu kontroli drużyna może też zdecydować,
+        że <span class="m-strong">oddaje pytanie</span> przeciwnikom.
+        Jest to ruch taktyczny: zamiast „dobić” pytanie, drużyna może przekazać szansę rywalom.
+        Panel udostępnia tę opcję tylko w odpowiednim momencie i pilnuje, żeby nie dało się jej nadużywać.
+      </p>
+    
+      <h3 class="m-h3">Rozgrywka pytania: odsłanianie odpowiedzi i bank</h3>
+    
+      <p class="m-p">
+        Po ustaleniu kontroli drużyna odpowiada, a operator odsłania trafione odpowiedzi na tablicy.
+        Każde trafienie dodaje punkty do <span class="m-strong">banku rundy</span>.
+        Bank jest widoczny na wyświetlaczu i rośnie wraz z kolejnymi trafieniami.
+      </p>
+    
+      <p class="m-p">
+        Rozgrywka trwa do momentu, gdy:
+        wszystkie odpowiedzi zostaną odsłonięte,
+        albo drużyna straci trzy „szanse” (trzy X),
+        wtedy operator zakończy etap i przejdzie do kradzieży (gdy są spełnione warunki).
+      </p>
+    
+      <h3 class="m-h3">Pudła (X) i limit 3 sekund</h3>
+    
+      <p class="m-p">
+        Błędna odpowiedź jest oznaczana symbolem <span class="m-strong">X</span> na tablicy.
+        Trzy błędy oznaczają utratę kontroli i przejście do kradzieży przez przeciwników.
+        System ma także mechanikę limitu czasu <span class="m-strong">3 sekund</span> na odpowiedź —
+        przekroczenie limitu jest traktowane jak pudło (X).
+      </p>
+    
+      <div class="m-note">
+        <b>Po co timer?</b><br/>
+        To jest „bat na tempo”. Timer pozwala operatorowi szybko zamknąć zawahanie
+        bez dyskusji i utrzymać rytm rozgrywki.
+      </div>
+    
+      <h3 class="m-h3">Kradzież banku (jedna odpowiedź)</h3>
+    
+      <p class="m-p">
+        Gdy drużyna grająca wykorzysta trzy „szanse” zanim odsłoni wszystkie odpowiedzi,
+        pytanie przechodzi do drużyny przeciwnej.
+        Przeciwnicy mają prawo do <span class="m-strong">jednej odpowiedzi</span>:
+        jeśli trafi — bank przechodzi do nich,
+        jeśli nie — bank zostaje u drużyny grającej.
+        To domyka pytanie i rundę zgodnie z regulaminem.
+      </p>
+    
+      <h3 class="m-h3">Odsłanianie brakujących odpowiedzi i zakończenie rundy</h3>
+    
+      <p class="m-p">
+        Po rozstrzygnięciu pytania operator może odsłonić brakujące odpowiedzi „informacyjnie”,
+        żeby widzowie zobaczyli pełną tablicę.
+        Następnie operator kończy rundę: bank jest dopisywany właściwej drużynie,
+        z uwzględnieniem mnożnika rundy.
+      </p>
+    
+      <div class="m-note">
+        <b>Praktyczna uwaga:</b><br/>
+        Panel celowo rozdziela „rozgrywkę pytania” od „zakończenia rundy”.
+        Dzięki temu operator nie skasuje przypadkiem stanu tablicy,
+        zanim prowadzący dopowie puentę lub zanim padnie „dziękujemy”.
+      </div>
+
+      <h3 class="m-h3">Zakończenie rund i przejście dalej</h3>
+      
+      <p class="m-p">
+        Po każdej rundzie system aktualizuje wynik drużyn i sprawdza,
+        czy spełniono warunek zakończenia rozgrywki (ustawiony w „Dodatkowych ustawieniach”).
+        Najczęściej jest to próg punktów, np. <span class="m-strong">300</span>,
+        ale może być inny — zależnie od tego, jak chcesz poprowadzić turniej.
+      </p>
+      
+      <p class="m-p">
+        Jeśli finał jest <span class="m-strong">włączony</span>, a warunek zakończenia rund został spełniony,
+        rozgrywka przechodzi do finału.
+        Jeśli finał jest <span class="m-strong">wyłączony</span>, rozgrywka kończy się po rundach
+        i system przechodzi do ekranu zakończenia (logo/punkty/kwota — zgodnie z ustawieniami).
+      </p>
+      
+      <div class="m-warn">
+        <b>Uwaga:</b><br/>
+        Jeśli w trakcie rozgrywki skończą się pytania,
+        zanim zostanie osiągnięty próg punktowy,
+        system zakończy rundy z powodu braku pytań.
+        Wtedy rozgrywka przejdzie do finału (jeśli jest włączony)
+        albo do zakończenia gry (jeśli finał jest wyłączony).
+      </div>
+    
+    <h3 class="m-h2">4) Finał</h3>
+
+      <p class="m-p">
+        Finał jest osobnym trybem gry. Bierze w nim udział dwóch zawodników
+        z drużyny, która wygrała rozgrywkę zasadniczą.
+        Odpowiadają na te same <span class="m-strong">5 pytań</span>,
+        a ich punkty sumują się. Celem jest osiągnięcie progu finału
+        (domyślnie <span class="m-strong">200 punktów</span>, chyba że ustawiono inaczej).
+      </p>
+      
+      <h3 class="m-h3">Przygotowanie finału</h3>
+      
+      <p class="m-p">
+        Zanim rozpoczniesz finał, w ustawieniach gry musisz mieć wybrane i zatwierdzone
+        <span class="m-strong">dokładnie 5 pytań finałowych</span>.
+        Dzięki temu finał jest gotowy do poprowadzenia bez szukania pytań w trakcie.
+      </p>
+      
+      <p class="m-p">
+        Drugi zawodnik nie powinien znać odpowiedzi pierwszego.
+        W praktyce na czas tury pierwszego zawodnika
+        drugi zawodnik odwraca się albo zakłada słuchawki z muzyką.
+      </p>
+      
+      <h3 class="m-h3">Przygotowanie finału</h3>
+      
+      <p class="m-p">
+        Zanim rozpoczniesz finał, w ustawieniach gry musisz mieć wybrane i zatwierdzone
+        <span class="m-strong">dokładnie 5 pytań finałowych</span>.
+        Dzięki temu finał jest gotowy do poprowadzenia bez szukania pytań w trakcie.
+      </p>
+      
+      <p class="m-p">
+        W finale bardzo ważne jest, żeby drugi zawodnik nie znał odpowiedzi pierwszego.
+        Dlatego w czasie rundy pierwszego zawodnika drugi zawodnik
+        <span class="m-strong">oddala się i zakłada słuchawki z muzyką</span>,
+        żeby nie słyszeć pytań ani odpowiedzi.
+      </p>
+      
+      <h3 class="m-h3">Runda 1 – pierwszy zawodnik (15 sekund)</h3>
+      
+      <p class="m-p">
+        Prowadzący czyta po kolei pięć pytań, a pierwszy zawodnik odpowiada w limicie
+        <span class="m-strong">15 sekund</span>.
+        Operator w tym czasie <span class="m-strong">wpisuje odpowiedzi</span> w panelu finału.
+        Na tym etapie odpowiedzi nie są jeszcze oceniane ani odsłaniane.
+      </p>
+      
+      <p class="m-p">
+        Po zakończeniu rundy operator przypisuje wpisane odpowiedzi do listy punktowanych wyników
+        i <span class="m-strong">odsłania je na tablicy</span>.
+        Jeśli odpowiedź nie pasuje do żadnej pozycji z listy,
+        otrzymuje <span class="m-strong">0 punktów</span>.
+      </p>
+      
+      <p class="m-p">
+        Po odsłonięciu odpowiedzi pierwszego zawodnika system ukrywa jego połowę tablicy,
+        a prowadzący przygotowuje wejście drugiego zawodnika i przypomina zasady finału.
+      </p>
+      
+      <h3 class="m-h3">Runda 2 – drugi zawodnik (20 sekund) i powtórki</h3>
+      
+      <p class="m-p">
+        Drugi zawodnik wraca do gry i odpowiada na te same pytania w limicie
+        <span class="m-strong">20 sekund</span>.
+        W momencie gdy na tablicy pojawia się połówka z odpowiedziami pierwszego zawodnika,
+        drugi zawodnik <span class="m-strong">odwraca się</span>,
+        żeby ich nie widzieć i nie sugerować się nimi.
+      </p>
+      
+      <p class="m-p">
+        Operator znów najpierw wpisuje wszystkie odpowiedzi drugiego zawodnika,
+        bez odsłaniania i bez oceniania „na bieżąco”.
+        Jeśli druga osoba poda odpowiedź identyczną jak pierwsza,
+        jest to <span class="m-strong">powtórka</span> — zawodnik musi podać inną odpowiedź,
+        a operator może oznaczyć tę próbę jako powtórzoną.
+        Odpowiedzi powtórzone nie dają punktów.
+      </p>
+      
+      <p class="m-p">
+        Po zakończeniu rundy operator przypisuje odpowiedzi drugiego zawodnika do listy punktowanych wyników
+        i <span class="m-strong">odsłania je po kolei</span> na tablicy.
+        Punkty obu zawodników sumują się.
+      </p>
+      
+      <h3 class="m-h3">Kiedy finał się kończy</h3>
+      
+      <p class="m-p">
+        Finał kończy się w momencie, gdy łączna liczba punktów osiągnie lub przekroczy
+        ustalony próg. Może się zdarzyć, że próg zostanie osiągnięty już po turze pierwszego zawodnika
+        — wtedy drugi zawodnik nie musi już grać, a rozgrywka przechodzi od razu do zakończenia.
+      </p>
+      
+      <p class="m-p">
+        Po zakończeniu finału system wyświetla ekran końcowy zgodnie z ustawieniami zakończenia gry:
+        <span class="m-strong">logo</span>, <span class="m-strong">punkty</span> albo
+        <span class="m-strong">kwotę wygranej</span>.
+      </p>`,
+      demo: `<p class="m-p">
+        W tej zakładce możesz przywrócić przykładowe materiały startowe:
+        bazę pytań, loga oraz gotowe gry różnych kategorii i stanów.
+      </p>
+  
+      <p class="m-p">
+        Przydaje się to, gdy:
+      </p>
+  
+      <ul class="m-ul">
+        <li>chcesz szybko zobaczyć jak działa system</li>
+        <li>testujesz funkcje bez tworzenia własnych danych</li>
+        <li>przypadkiem usunąłeś przykładową zawartość</li>
+      </ul>
+  
+      <div class="m-warn">
+        Przywracanie demo nie usuwa Twoich danych – dodaje tylko przykładowe materiały.
+      </div>
+  
+      <div class="m-box">
+        <button class="btn" id="demoRestoreBtn">
+          ↺ Przywróć pliki demo
+        </button>
+  
+        <p class="m-p m-muted" style="margin-top:10px">
+          Po kliknięciu nastąpi przejście do widoku Moje gry i automatyczne wgranie demo.
+        </p>
+      </div>`,
+    },
   },
   builderImportExport: {
     defaults: {

--- a/translation/uk.js
+++ b/translation/uk.js
@@ -780,6 +780,1321 @@ const uk = {
       modalOk: "Відновити",
       modalCancel: "Скасувати",
     },
+    content: {
+      general: `<p class="m-p">
+        This page is a guide to running a game (tournament)
+        in the style of “Familiada.” Its goal is to explain how to prepare a game,
+        collect results (polls), and smoothly run a live match
+        — even if someone uses the system for the first time.
+      </p>
+      
+      <p class="m-p">
+        The description focuses on the tool and how to use it,
+        not on “television production.” The system works well for events,
+        company parties, school, stage shows, or just with friends
+        — anywhere you want a clear board, points, and a smooth flow of play.
+      </p>
+      
+      <p class="m-p">
+        The gameplay is structured to closely match the official rules of Familiada
+        (rounds, bank, X errors, steals, and the final), but the whole thing is designed as
+        a convenient system for hosting the game/tournament, with a clear division of roles:
+        <span class="m-strong">the host leads the conversation and asks the questions</span>,
+        while <span class="m-strong">the operator controls the board and points</span>.
+      </p>
+
+      <p class="m-p">
+        If you want to read the full rules of the game,
+        <a href="https://s.tvp.pl/repository/attachment/6/8/f/68f09c03ff0781fa510c2fd90c3ba19b1569224834470.pdf"
+           target="_blank"
+           rel="noopener">
+          The “Familiada” game show rules
+        </a>
+        describe them in detail.
+      </p>
+
+      <p class="m-p">
+        The whole system is designed
+        to clearly separate content preparation
+        from the actual gameplay.
+        Questions, answers, and polls are prepared in advance,
+        while during the game the operator uses only
+        the control panel.
+      </p>
+
+      <p class="m-p">
+        In practice this means that on the day of the recording
+        the operator doesn’t edit data,
+        the host focuses on talking with the contestants,
+        and the system keeps track of stages and game logic.
+        This reduces the risk of mistakes and speeds up the flow of the game.
+      </p>
+
+      <p class="m-p">
+        The system works best when using separate devices:
+        a display for the audience (TV or projector),
+        a tablet or phone for the host,
+        a separate device acting as the buzzer,
+        and the operator’s computer with the control panel.
+      </p>
+
+      <p class="m-p">
+        The guide is divided into tabs.
+        Each tab describes a different stage of working with the system:
+        from preparing the game,
+        through polls,
+        to running the live gameplay.
+      </p>`,
+      edit: `<p class="m-p">
+        The “Creating and editing a game” tab describes the stage of preparing the game
+        before starting the poll or the live match.
+        At this stage you create the structure of the game:
+        questions, possible answers, and how they are scored.
+      </p>
+    
+      <p class="m-p">
+        This stage is key, because it determines
+        how all later work with the game will look.
+        The system deliberately separates content preparation
+        from later data collection and live gameplay.
+      </p>
+    
+      <h3 class="m-h2">Game list (“My games”)</h3>
+    
+      <p class="m-p">
+        The game list is the place where you manage all games
+        assigned to your account.
+        This is where you can create new games,
+        choose existing ones,
+        and decide what you want to do next.
+      </p>
+    
+      <p class="m-p">
+        Games are divided into types.
+        The game type determines how answers will be collected
+        and how points will be generated on the board later.
+      </p>
+    
+      <ul class="m-ul">
+        <li>
+          <span class="m-strong">Standard poll</span> —
+          answers are typed in by respondents,
+          and points are based on the number of mentions.
+        </li>
+        <li>
+          <span class="m-strong">Answer scoring</span> —
+          respondents choose from prepared answers,
+          and the system counts votes.
+        </li>
+        <li>
+          <span class="m-strong">Prepared</span> —
+          answers and points are set manually,
+          without a poll.
+        </li>
+      </ul>
+    
+      <p class="m-p">
+        You create a new game by clicking the tile with the “＋” symbol.
+        After creation the game appears on the list
+        and can be opened in the editor.
+      </p>
+    
+      <h3 class="m-h2">Game editor — what and when can be edited</h3>
+    
+     <p class="m-p">
+        You enter the game edit mode from the “My games” list
+        using the <span class="m-code">Edit</span> button.
+        This is the first stage of working on the game,
+        where you prepare its full content
+        before using it in a poll or live gameplay.
+      </p>
+      
+      <p class="m-p">
+        In edit mode you create questions and answers,
+        decide on the game type,
+        and prepare the structure
+        that will later be used
+        to collect data or run the live game.
+      </p>
+      
+      <p class="m-p">
+        The game editor is used to build the structure of questions and answers.
+        Depending on the game type and its state,
+        the available editing options may differ.
+      </p>
+    
+      <p class="m-p">
+        This is intentional.
+        The system limits certain operations
+        to keep data consistent
+        and prevent situations
+        where the gameplay or poll
+        no longer matches the prepared content.
+      </p>
+    
+      <h3 class="m-h3">Adding and editing questions</h3>
+    
+      <p class="m-p">
+        Questions are always the core element of the game.
+        During preparation you can:
+        add new questions,
+        change their wording,
+        and remove unnecessary questions.
+      </p>
+    
+      <p class="m-p">
+        Changing a question after a poll has started
+        may be blocked,
+        because even a small text change
+        affects the meaning of collected answers.
+      </p>
+    
+      <h3 class="m-h3">Adding and editing answers</h3>
+    
+      <p class="m-p">
+        The ability to edit answers depends on the game type.
+        In poll-based games answers are the result of a survey,
+        so before the poll you can only prepare
+        their general structure or examples.
+      </p>
+    
+      <p class="m-p">
+        After the poll starts, the system may limit
+        adding or removing answers
+        so that responses from respondents
+        are not mixed with new content.
+      </p>
+    
+      <h3 class="m-h3">Points — why they are sometimes locked</h3>
+    
+      <p class="m-p">
+        Points are not always editable by hand.
+        In poll-based games points result directly
+        from the number of answers given,
+        so manual editing makes no sense
+        and is blocked.
+      </p>
+    
+      <p class="m-p">
+        Manual point setting is possible
+        only in prepared mode,
+        where the system does not use survey data.
+      </p>
+    
+      <div class="m-note">
+        <b>Why is that?</b><br/>
+        Thanks to this, what the audience sees on the board
+        always matches the actual poll results
+        or a clearly defined, manual scoring.
+      </div>
+    
+      <h3 class="m-h2">Length and format limits</h3>
+    
+      <p class="m-p">
+        Answers should be short and readable.
+        When importing content, answers longer
+        than <span class="m-strong">17 characters</span>
+        are automatically trimmed.
+      </p>
+    
+      <p class="m-p">
+        This limit comes from the board layout
+        and aims to keep things readable
+        during live gameplay.
+      </p>
+    
+      <h3 class="m-h2">Importing and exporting games</h3>
+    
+      <p class="m-p">
+        Builder allows exporting and importing games
+        as files or directly into a question base.
+        This feature is used to move games and questions
+        between accounts or environments.
+      </p>
+    
+      <p class="m-p">
+        Import and export files are a technical format.
+        You should not alter their contents
+        or try to edit them manually.
+      </p>
+    
+      <div class="m-warn">
+        <b>Warning:</b>
+        manual modification of import or export files
+        can make a game impossible to import
+        or cause it to work incorrectly.
+      </div>
+    
+      <p class="m-p">
+        After a successful import, the game appears
+        in the game list and can be further edited
+        only using the system editor.
+      </p>
+      
+      <p class="m-p">
+        When exporting a game to a base:
+      </p>
+      
+      <ul class="m-ul">
+        <li>a new folder is created in the base root</li>
+        <li>the folder is named after the game</li>
+        <li>all questions belonging to the game are saved inside</li>
+      </ul>
+
+      <p class="m-note">
+        You can export only to your own base or to a shared base where you are an editor.
+        If you do not currently have any bases, you will not be able to export.
+      </p>
+      
+      <p class="m-p">
+        Thanks to this each game can be turned into a set of questions for further editing,
+        organizing into folders, tagging, and reusing
+        in future games.
+      </p>
+      
+      <p class="m-note">
+        Exporting to a base does not remove the game — it only creates a copy as a question structure.
+      </p>`,
+      bases: `<h2 class="m-h2">Question bases — organization and collaboration</h2>
+  
+      <p class="m-p">
+        Question bases are a central place for storing all questions used in games.
+        They let you organize questions in folders, tag them, assign categories,
+        and share entire bases with other users.
+      </p>
+      <p class="m-p">
+        You access question bases from the top bar of the “My games” page
+        using the <span class="m-code">Question bases 🗃️</span> button.
+      </p>
+  
+      <p class="m-p">
+        A single base can contain hundreds or thousands of questions organized in a structure similar
+        to a classic file manager on a computer.
+      </p>
+  
+      <h3 class="m-h3">➕ Adding a new base</h3>
+  
+      <p class="m-p">
+        In the “Question bases” view click the <span class="m-strong">New base</span> tile.
+        A window will open where you enter the base name.
+      </p>
+  
+      <p class="m-p">
+        After saving, the new base appears in the list and you can immediately browse or share it.
+      </p>
+  
+      <h3 class="m-h3">🤝 Sharing a base</h3>
+  
+      <p class="m-p">
+        You can share any base with other users by providing their email address.
+        Two modes are available:
+      </p>
+  
+      <ul class="m-ul">
+        <li><span class="m-strong">Edit</span> — the user can add, delete, and modify questions, folders, tags, create games from questions, and export questions to a base</li>
+        <li><span class="m-strong">View</span> — the user can only browse the base and create games from available questions</li>
+      </ul>
+  
+      <p class="m-p">
+        Only the base owner can manage sharing.
+      </p>
+  
+      <h3 class="m-h3">📂 Opening the base manager</h3>
+  
+      <p class="m-p">
+        To enter a base, select it in the list and click the <span class="m-code">Browse</span> button.
+      </p>
+  
+      <p class="m-p">
+        Base Explorer will open — an advanced question manager that works like a classic file explorer.
+      </p>
+  
+      <h2 class="m-h2">Base Explorer — question manager</h2>
+  
+      <p class="m-p">
+        Base Explorer lets you manage questions in a way familiar from system file managers:
+        folders, drag-and-drop moves, copy, cut, and quick selection.
+      </p>
+  
+      <p class="m-p">
+        Each “file” in this manager is a single question.
+        Folders are used to group questions thematically or logically.
+      </p>
+  
+      <p class="m-p">
+        You can:
+      </p>
+  
+      <ul class="m-ul">
+        <li>create arbitrarily nested folders</li>
+        <li>move questions and folders between each other</li>
+        <li>copy and duplicate items</li>
+        <li>delete selected items</li>
+        <li>search by name and tags</li>
+      </ul>
+  
+      <p class="m-note">
+        The interface and keyboard shortcuts work similarly to classic file managers
+        (Explorer, Finder, Total Commander).
+      </p>
+  
+      <h2 class="m-h2">Tags and categories</h2>
+  
+      <h3 class="m-h3">🏷️ Tags</h3>
+  
+      <p class="m-p">
+        Each question can have any number of tags.
+        Tags are used to label questions by topic — e.g. “history,” “sports,” “easy,” “for kids.”
+      </p>
+  
+      <p class="m-p">
+        You can:
+      </p>
+  
+      <ul class="m-ul">
+        <li>create your own tags with colors</li>
+        <li>assign multiple tags to a single question</li>
+        <li>filter the view by selected tags</li>
+      </ul>
+
+      <p class="m-p">
+        Tag assignment takes place in a dedicated window, which you can open from the toolbar
+        or the context menu.
+      </p>
+      
+      <p class="m-p">
+        In the tag assignment window you can see a list of all available tags and their states:
+      </p>
+      
+      <ul class="m-ul">
+        <li>selected — the tag is assigned to all selected items</li>
+        <li>unselected — the tag is assigned to none of them</li>
+        <li>partial — only part of the selection has the tag</li>
+      </ul>
+      
+      <p class="m-p">
+        Clicking a tag cycles its state, enabling quick adding and removing of tags
+        for many questions or folders at once. This window also allows creating new tags.
+      </p>
+      
+      <p class="m-p">
+        Tags can also be used as filters — clicking a tag on the left narrows the view
+        to items marked with the selected tag or tag set.
+      </p>
+  
+      <p class="m-note">
+        A folder shows tag markers when all questions inside it
+        (and subfolders) have the same tag.
+      </p>
+  
+      <h3 class="m-h3">📌 Categories</h3>
+  
+      <p class="m-p">
+        Categories are special system labels that indicate
+        which game type a given question fits. This corresponds to game types in the <span class="m-strong">My games</span> view.
+      </p>
+  
+      <p class="m-p">
+        For example:
+      </p>
+  
+      <ul class="m-ul">
+        <li>questions with answers and points go to the <span class="m-strong">prepared</span> category</li>
+        <li>questions with answers but no points total go to <span class="m-strong">scoring</span></li>
+        <li>text-only questions without points go to <span class="m-strong">standard</span></li>
+      </ul>
+  
+      <p class="m-p">
+        Categories are assigned automatically based on the question structure,
+        not manually by the user.
+      </p>
+  
+      <p class="m-note">
+        This way you immediately know which questions suit a specific game type.
+      </p>
+  
+      <h2 class="m-h2">Question editor</h2>
+  
+      <p class="m-p">
+        You can open any question in the editor.
+        The editor lets you change the question text, answers, and points (if present).
+      </p>
+  
+      <p class="m-p">
+        The system enforces basic rules such as:
+      </p>
+  
+      <ul class="m-ul">
+        <li>the maximum number of points for a single answer</li>
+        <li>the total sum of points in a question</li>
+      </ul>
+  
+      <p class="m-p">
+        Thanks to this the base always stays consistent and ready for use in games.
+      </p>
+  
+      <h2 class="m-h2">Creating a game from questions</h2>
+  
+      <p class="m-p">
+        In the base manager you can select any questions and folders (including subfolders),
+        and then create a new game from them.
+      </p>
+  
+      <p class="m-p">
+        The system collects all questions from the selection, lets you review them,
+        and choose the game type.
+      </p>
+
+      <p class="m-note">
+        This enables fast game building from ready sets of questions without manual retyping.
+      </p>
+
+      <p class="m-warn">
+        After successful game creation you will be redirected to the <span class="m-strong">My games</span> view.
+      </p>
+  
+      <h2 class="m-h2">⌨️ Keyboard shortcuts — Base manager</h2>
+  
+      <h3 class="m-h3">📁 Create</h3>
+  
+      <table class="m-table">
+        <tr><th>Action</th><th>Windows / Linux</th><th>macOS</th></tr>
+        <tr><td>New question</td><td>Ctrl + N</td><td>⌘ N</td></tr>
+        <tr><td>New folder</td><td>Ctrl + Shift + N</td><td>⌘ ⇧ N</td></tr>
+      </table>
+  
+      <h3 class="m-h3">✏️ Edit</h3>
+  
+      <table class="m-table">
+        <tr><th>Action</th><th>Windows / Linux</th><th>macOS</th></tr>
+        <tr><td>Edit question</td><td>Ctrl + E</td><td>⌘ E</td></tr>
+        <tr><td>Rename</td><td>F2</td><td>F2</td></tr>
+        <tr><td>Delete</td><td>Delete</td><td>Fn + ⌫</td></tr>
+      </table>
+  
+      <h3 class="m-h3">📋 Clipboard</h3>
+  
+      <table class="m-table">
+        <tr><th>Action</th><th>Windows / Linux</th><th>macOS</th></tr>
+        <tr><td>Copy</td><td>Ctrl + C</td><td>⌘ C</td></tr>
+        <tr><td>Cut</td><td>Ctrl + X</td><td>⌘ X</td></tr>
+        <tr><td>Paste</td><td>Ctrl + V</td><td>⌘ V</td></tr>
+        <tr><td>Duplicate</td><td>Ctrl + D</td><td>⌘ D</td></tr>
+      </table>
+  
+      <h3 class="m-h3">🎮 Game</h3>
+  
+      <table class="m-table">
+        <tr><th>Action</th><th>Windows / Linux</th><th>macOS</th></tr>
+        <tr><td>Create game</td><td>Ctrl + G</td><td>⌘ G</td></tr>
+      </table>
+  
+      <h3 class="m-h3">🔄 View</h3>
+  
+      <table class="m-table">
+        <tr><th>Action</th><th>Windows / Linux</th><th>macOS</th></tr>
+        <tr><td>Refresh view</td><td>Ctrl + Alt + R</td><td>⌘ ⌥ R</td></tr>
+      </table>
+  
+      <h3 class="m-h3">📌 Navigation</h3>
+  
+      <table class="m-table">
+        <tr><th>Action</th><th>Windows / Linux</th><th>macOS</th></tr>
+        <tr><td>Select all</td><td>Ctrl + A</td><td>⌘ A</td></tr>
+        <tr><td>Open folder</td><td>Enter</td><td>⏎</td></tr>
+        <tr><td>Parent folder</td><td>Backspace</td><td>⌫</td></tr>
+      </table>
+  
+      <p class="m-note">
+        Shortcuts do not work while typing in edit fields.
+      </p>`,
+      polls: `<p class="m-p">
+        The “Polls” tab describes the stage of collecting responses
+        from respondents before the live match.
+        The poll is a bridge between game preparation
+        and the live gameplay.
+      </p>
+    
+      <p class="m-p">
+        At this stage the system stops being a content editor
+        and starts working as a data collection tool.
+        For this reason many editing options are deliberately limited.
+      </p>
+
+      <p class="m-p">
+        You reach polls from the “My games” list
+        using the <span class="m-code">Polls Hub</span> button.
+        This stage happens after finishing game editing
+        and is used only to collect responses
+        or votes from respondents.
+      </p>
+      
+      <p class="m-p">
+        When a poll starts,
+        the game stops being editable
+        and begins serving as a data collection tool.
+        Therefore some options available in the editor
+        are deliberately blocked in this mode.
+      </p>
+
+      <h3 class="m-h2">Polls hub (polls-hub)</h3>
+
+      <p class="m-p">
+        The polls hub is a separate panel for managing polls, tasks, and subscriptions.
+        You open it from the “My games” list with the <span class="m-code">Polls Hub</span> button.
+        On desktop you see two cards, each with two lists.
+      </p>
+
+      <ul class="m-ul">
+        <li><span class="m-strong">Polls</span> — the “My polls” list and “Tasks.”</li>
+        <li><span class="m-strong">Subscriptions</span> — the “My subscribers” list and “My subscriptions.”</li>
+      </ul>
+
+      <p class="m-p">
+        The gold dot on the “Polls” card shows the number of active tasks to complete,
+        and on the “Subscriptions” card the number of invitations to accept.
+      </p>
+
+      <p class="m-p">
+        A subscription is a permanent connection between your account and an invited user —
+        once accepted, it allows sharing future polls without re-entering the email.
+        You send an invitation in the “My subscribers” section by entering an email or username
+        and clicking <span class="m-code">Invite</span>. The recipient accepts the invite in their
+        Polls Hub or via the link in the message, and the status becomes active.
+      </p>
+
+      <p class="m-p">
+        Sharing a poll is done from the “My polls” list: select the tile and click
+        <span class="m-code">Share</span>, then choose subscribers and save.
+        The poll tile shows current votes, and the <span class="m-code">Details</span> button
+        provides a view of submitted votes, pending, rejected, and anonymous responses.
+      </p>
+
+      <h3 class="m-h3">My polls</h3>
+      <p class="m-p">
+        Each tile has a color that indicates the poll status:
+      </p>
+      <ul class="m-ul">
+        <li><span class="m-strong">Gray</span> — draft, missing requirements to start.</li>
+        <li><span class="m-strong">Red</span> — draft ready to start.</li>
+        <li><span class="m-strong">Orange</span> — poll open, no votes.</li>
+        <li><span class="m-strong">Yellow</span> — poll open, there are votes or active tasks.</li>
+        <li><span class="m-strong">Green</span> — poll open, goals reached (tasks done or ≥10 votes).</li>
+        <li><span class="m-strong">Blue</span> — poll closed.</li>
+      </ul>
+
+      <h3 class="m-h3">Tasks</h3>
+      <p class="m-p">
+        Tasks are voting invitations. Colors:
+        <span class="m-strong">green</span> — available,
+        <span class="m-strong">blue</span> — completed.
+        Double-click opens voting, and the <span class="m-code">X</span> button rejects the task.
+      </p>
+
+      <h3 class="m-h3">My subscribers</h3>
+      <p class="m-p">
+        Status colors:
+        <span class="m-strong">yellow</span> — pending,
+        <span class="m-strong">green</span> — active,
+        <span class="m-strong">red</span> — rejected/canceled.
+        The <span class="m-code">X</span> button removes a subscriber, and <span class="m-code">↻</span> resends an invite.
+      </p>
+
+      <h3 class="m-h3">My subscriptions</h3>
+      <p class="m-p">
+        Colors:
+        <span class="m-strong">yellow</span> — pending,
+        <span class="m-strong">green</span> — active.
+        Buttons: <span class="m-code">✓</span> accepts, <span class="m-code">X</span> rejects/cancels.
+      </p>
+
+    
+      <h3 class="m-h2">Types of polls</h3>
+    
+      <p class="m-p">
+        Depending on the game type, a poll can work in one of two modes:
+      </p>
+    
+      <ul class="m-ul">
+        <li>
+          <span class="m-strong">Standard (text) poll</span> —
+          respondents type their own text answers.
+        </li>
+        <li>
+          <span class="m-strong">Scoring poll</span> —
+          respondents choose one of the prepared answers.
+        </li>
+      </ul>
+    
+      <p class="m-p">
+        Prepared games do not have a poll —
+        answers and points are set manually.
+      </p>
+    
+      <h3 class="m-h2">Starting a poll</h3>
+    
+      <p class="m-p">
+        A poll can be started only for a game
+        in the <span class="m-strong">Draft</span> state.
+        Before starting, the system checks
+        whether the game meets the minimum requirements.
+      </p>
+    
+      <ul class="m-ul">
+        <li>minimum number of questions,</li>
+        <li>in scoring mode — the required number of answers per question.</li>
+      </ul>
+    
+      <div class="m-note">
+        <b>Why?</b><br/>
+        This ensures you cannot start a poll
+        that cannot later be properly closed
+        and used in the game.
+      </div>
+    
+      <h3 class="m-h2">Link and QR code</h3>
+    
+      <p class="m-p">
+        After starting a poll the system generates
+        a unique voting link.
+        The link can be copied,
+        opened in a new tab,
+        or displayed as a QR code.
+      </p>
+    
+      <p class="m-p">
+        The QR code is intended to be displayed
+        on a screen visible to respondents
+        (TV, projector, large monitor).
+      </p>
+    
+      <h3 class="m-h2">Poll flow</h3>
+    
+      <p class="m-p">
+        Respondents go through the questions in order.
+        The system enforces the order
+        and does not allow skipping a question.
+      </p>
+    
+      <p class="m-p">
+        In a text poll each answer:
+      </p>
+    
+      <ul class="m-ul">
+        <li>is limited to 17 characters,</li>
+        <li>is normalized (case, spaces),</li>
+        <li>is counted as a separate proposal.</li>
+      </ul>
+    
+      <p class="m-p">
+        In a scoring poll the respondent
+        chooses one of the prepared answers,
+        and the system records the vote.
+      </p>
+    
+      <h3 class="m-h2">Closing a poll</h3>
+    
+      <p class="m-p">
+        Closing a poll is a separate,
+        deliberate stage of work.
+        The system will not allow closing a poll
+        if the collected data does not meet
+        minimum quality conditions.
+      </p>
+    
+      <h3 class="m-h3">Scoring poll</h3>
+    
+      <p class="m-p">
+        When closing a scoring poll
+        the system converts votes into points
+        and normalizes them to a 0–100 scale
+        for each question.
+      </p>
+    
+      <div class="m-note">
+        <b>Result:</b>
+        you get a ready list of answers with points,
+        without the need for manual counting.
+      </div>
+    
+      <h3 class="m-h3">Text poll</h3>
+    
+      <p class="m-p">
+        In a text (classic) poll respondents type their own answers.
+        After closing, the system moves to the results cleanup stage.
+        The operator can merge obviously similar answers
+        and remove typos or clear duplicates.
+      </p>
+      
+      <p class="m-p">
+        Then answers are normalized to the points scale.
+        At this stage the system applies additional limits
+        aimed at keeping the board readable
+        and the gameplay dynamic.
+      </p>
+      
+      <p class="m-p">
+        Answers with a very low number of mentions
+        that after normalization get
+        <span class="m-strong">less than 8 points</span>
+        are automatically discarded.
+        Such answers usually do not matter for the game
+        and would not be readable for the audience.
+      </p>
+      
+      <p class="m-p">
+        For one question, the board can show at most
+        <span class="m-strong">6 answers</span>.
+        If there are more correct answers,
+        the system selects the highest-scoring ones
+        and skips the rest.
+      </p>
+      
+      <p class="m-p">
+        For this reason the total points for a single question
+        <span class="m-strong">do not always sum to exactly 100</span>.
+        Points are assigned only to the answers
+        that actually appear on the board.
+      </p>
+    
+      <div class="m-warn">
+        <b>Warning:</b>
+        after closing a poll
+        you cannot change its results
+        without restarting the poll.
+      </div>
+    
+      <h3 class="m-h2">Restarting a poll</h3>
+    
+      <p class="m-p">
+        A closed poll can be restarted,
+        which removes previous results
+        and starts collecting answers from scratch.
+      </p>
+    
+      <p class="m-p">
+        This option is useful
+        when the poll was started for testing
+        or an organizational error occurred.
+      </p>`,
+      logo: `<p class="m-p">
+      The system lets you set your own logo that appears on the display
+      (e.g., the start or end screen). You can access the logo creator from the top bar of the “My games” page
+        using the <span class="m-code">Logo🖥️</span> button.
+    </p>
+
+    <div class="m-note">
+      <b>Important:</b><br/>
+      The logo has a technical size of <span class="m-code">30×10</span> (character tiles) or <span class="m-code">150×70</span> (pixels).
+      This limitation comes from the physical layout of the board and ensures readability live.
+    </div>
+
+    <h3 class="m-h2">Logo creation modes</h3>
+
+    <p class="m-p">
+      When creating a new logo you choose one of the modes.
+      Each mode leads to the same result (a logo on the display),
+      but differs in how it is created.
+    </p>
+
+    <ul class="m-ul">
+      <li>
+        <span class="m-strong">Text art</span> — a classic logo made of characters (the “Familiada” style).
+        Good when you want a quick, readable title.
+      </li>
+      <li>
+        <span class="m-strong">Text</span> — text editing and preview in “pixels.”
+        Good when you need a different font/layout than “Text art.”
+      </li>
+      <li>
+        <span class="m-strong">Drawing</span> — draw by hand on a grid (like a simple graphics editor).
+        Good for icons and simple shapes.
+      </li>
+      <li>
+        <span class="m-strong">Image</span> — import an image and fit it to the board.
+        Good when you already have a company logo.
+      </li>
+    </ul>
+
+    <h3 class="m-h2">Display preview</h3>
+
+    <p class="m-p">
+      In the editor you always see a preview “as on the board.”
+      This is important because what looks good in high resolution
+      may be unreadable when reduced to <span class="m-code">150×70</span>.
+    </p>
+
+    <div class="m-note">
+      <b>Practical tip:</b><br/>
+      Thick shapes, large letters, and high contrast work best.
+      Thin lines, small details, and subtle gradients usually disappear.
+    </div>
+
+    <h3 class="m-h2">Saving and active logo</h3>
+
+    <p class="m-p">
+      You can save a logo under your own name. In the logo list you can also set
+      which logo is <span class="m-strong">active</span>.
+      The active logo will be used by the display automatically.
+    </p>
+
+    <p class="m-p">
+      If you do not set any active logo, the system uses
+      the <span class="m-strong">default logo</span>.
+    </p>
+
+    <h3 class="m-h2">Logo import and export</h3>
+
+    <p class="m-p">
+      The editor allows exporting the active logo to a file and importing a logo from a file.
+      This lets you move logos between accounts or make backups.
+    </p>
+
+    <div class="m-warn">
+      <b>Warning:</b><br/>
+      Do not edit logo files manually. This is a technical format — manual changes may cause
+      the import to fail or the logo to work incorrectly.
+    </div>`,
+      control: `<p class="m-p">
+        You reach the Control Panel from the “My games” list
+        using the <span class="m-code">Play</span> button.
+        This mode is intended only for running the live game —
+        you no longer edit questions or poll results here.
+      </p>
+    
+      <p class="m-p">
+        The control panel guides the operator step by step:
+        first you connect devices, then set game parameters,
+        and finally go through rounds and (optionally) the final.
+        Each step unlocks only when the previous one is ready,
+        which minimizes the risk of mistakes during recording.
+      </p>
+    
+      <h3 class="m-h2">What must be ready before you start</h3>
+    
+      <ul class="m-ul">
+        <li>
+          The game should have prepared questions and answers (from the editor),
+          and if it is a poll-based game — the poll should be closed and approved.
+        </li>
+        <li>
+          The operator should have a computer with a large screen (the panel is designed for desktop mode).
+        </li>
+        <li>
+          Separate devices should be prepared: a display (TV/projector), the host’s device,
+          and a device acting as the buzzer.
+        </li>
+        <li>
+          Stable Wi-Fi (the most common issues are killed background tabs / network switching).
+        </li>
+      </ul>
+    
+      <div class="m-note">
+        <b>Why so many “formalities”?</b><br/>
+        The gameplay is live and has a TV pace. The control panel is meant to enforce the procedure,
+        not add stress for the operator. That’s why the system requires readiness of equipment and settings before starting.
+      </div>
+    
+      <h3 class="m-h2">Who sees what</h3>
+    
+      <p class="m-p">
+        The system deliberately separates screens so everyone does their job:
+      </p>
+    
+      <ul class="m-ul">
+        <li>
+          <span class="m-strong">Operator (Control Panel)</span> — sees all buttons,
+          game status, bank, Xs, messages, and the next procedural steps.
+          The operator controls what appears on the board.
+        </li>
+        <li>
+          <span class="m-strong">Display</span> — shows the game board: questions, answers,
+          points, bank, errors (X), and start/end screens.
+          This is the screen visible to participants and the audience.
+        </li>
+        <li>
+          <span class="m-strong">Host</span> — receives content to read and a context preview,
+          but does not control the course of the game (the operator does).
+        </li>
+        <li>
+          <span class="m-strong">Buzzer</span> — used to signal the face-off (who is first).
+        </li>
+      </ul>
+    
+      <h3 class="m-h2">1) Devices</h3>
+    
+      <p class="m-p">
+        The first stage in the panel is connecting devices.
+        In the top bar you see three statuses:
+        <span class="m-strong">Display</span>,
+        <span class="m-strong">Host</span>,
+        <span class="m-strong">Buzzer</span>.
+        The operator starts by making sure all are online.
+      </p>
+    
+      <h3 class="m-h3">Step 1: Display</h3>
+    
+      <p class="m-p">
+        In this step the panel shows a QR code and link for the display.
+        It’s best to open the display on a TV or projector,
+        in full-screen mode (no browser bars).
+        Only when the display is online will the panel allow you to proceed.
+      </p>
+    
+      <h3 class="m-h3">Step 2: Host and buzzer</h3>
+    
+      <p class="m-p">
+        In the second step you connect the host device and the buzzer device.
+        The panel also shows a QR/link for connection.
+        In practice it’s best to use two separate phones or a phone and a tablet.
+      </p>
+    
+      <p class="m-p">
+        In this step there is an option <span class="m-strong">“QR on display”</span> —
+        after using it the QR codes can be shown on the large screen,
+        so the crew can quickly scan them with phones.
+        This speeds up the start on set because there is no need to type links manually.
+      </p>
+    
+      <div class="m-warn">
+        <b>Warning:</b><br/>
+        If any device disconnects during the game, the panel can show a warning.
+        Most often it helps to disable battery saving, avoid minimizing the browser,
+        and keep devices on one stable Wi-Fi network.
+      </div>
+    
+      <h3 class="m-h3">Step 3: Sound</h3>
+    
+      <p class="m-p">
+        Browsers block automatic sound playback
+        until the user performs a “gesture” (click).
+        That’s why the panel has a separate step to unlock sound.
+        Without it you may not hear signals that help keep the game pace.
+      </p>
+    
+      <h3 class="m-h2">2) Settings</h3>
+    
+      <p class="m-p">
+        When devices are online, you move on to game settings.
+        This stage has two goals:
+        (1) prepare readable team names on the board,
+        (2) adjust game parameters to the recording (additional settings).
+      </p>
+    
+      <h3 class="m-h3">Team names</h3>
+    
+      <p class="m-p">
+        You set the names of Team A and Team B.
+        These are the labels seen by players and the audience on the display,
+        so it’s best to decide them before the rounds begin.
+        The panel blocks moving forward until both names are entered.
+      </p>
+    
+      <h3 class="m-h3">Additional settings (important for the operator)</h3>
+    
+      <p class="m-p">
+        In “Additional settings” you tailor the game to the episode format.
+        These options do not change the rules’ meaning, only the pace and thresholds.
+      </p>
+    
+      <ul class="m-ul">
+        <li>
+          <span class="m-strong">Round multipliers</span> — entered comma-separated (e.g. <span class="m-code">1,1,1,2,3</span>).
+          This matches the classic doubling/tripling values in later stages.
+          In practice: the round bank at the end is multiplied by the current round multiplier.
+        </li>
+        <li>
+          <span class="m-strong">Game target</span> — the point threshold after which the game can go to the final
+          (in the classic format often 300). This lets you adjust the game length.
+        </li>
+        <li>
+          <span class="m-strong">Final target</span> — the point threshold in the final (default 200 in the classic format).
+        </li>
+        <li>
+          <span class="m-strong">Game ending</span> — what the display shows at the end
+          (logo / points / final prize). This is production-important: the “last frame.”
+        </li>
+      </ul>
+    
+      <div class="m-note">
+        <b>Why is this in the Control Panel and not in the editor?</b><br/>
+        Because these are episode (production) settings, not question content.
+        Questions shouldn’t change during the game, but game parameters sometimes do.
+      </div>
+    
+      <h3 class="m-h3">Final: enable and choose 5 questions</h3>
+    
+      <p class="m-p">
+        If the game should have a final, you enable it and choose exactly <span class="m-strong">5 final questions</span>.
+        The panel shows a list of questions and a list “Final questions (max 5)”.
+        After selecting five, you use the <span class="m-strong">Confirm</span> button.
+      </p>
+    
+      <div class="m-warn">
+        <b>Warning:</b><br/>
+        The final requires 5 confirmed questions before rounds start.
+        This is an intentional lock — in live play there’s no time to pick questions “on the fly.”
+        If you want to change the set, use the <span class="m-strong">Edit</span> mode for final questions.
+      </div>
+    
+      <h3 class="m-h2">3) Rounds — gameplay step by step</h3>
+    
+      <p class="m-p">
+        In rounds you conduct the main gameplay: questions, answers, points, and the round bank.
+        Players see the board on the display, the host asks questions and keeps the flow,
+        while the operator reveals answers, counts points, and adds errors (X).
+      </p>
+      
+      <p class="m-p">
+        The most important practical rule: the host focuses on the contestants,
+        and the operator on running the system. This keeps the game smooth,
+        and the board always shows what it should at any moment.
+      </p>
+    
+      <h3 class="m-h3">Round start: “Game ready” and intro</h3>
+    
+      <p class="m-p">
+        When starting rounds, the panel first prepares the display (clears the board and sets the game state),
+        and then lets you start the intro.
+        This organizes the beginning of the recording: the audience gets a clear start,
+        and the operator has a clear moment to enter the first question.
+      </p>
+    
+      <h3 class="m-h3">Face-off: who takes control</h3>
+    
+      <p class="m-p">
+        Each question starts with the “family heads” face-off at the podium.
+        At this moment the <span class="m-strong">Buzzer</span> device is key:
+        the signal from the buzzer tells the panel someone pressed first.
+        The operator confirms which side gains priority,
+        and the host moves on to the answers.
+      </p>
+    
+      <p class="m-p">
+        According to the rules, if the first answer is not the highest-scoring,
+        the second “head” can answer better and take control.
+        The panel guides the operator through the round control decision,
+        and the display shows which team is currently playing (team indicator).
+      </p>
+
+      <h3 class="m-h3">Giving up the question</h3>
+    
+      <p class="m-p">
+        According to game arrangements, after gaining control a team can also decide
+        that it <span class="m-strong">gives up the question</span> to the opponents.
+        This is a tactical move: instead of “finishing” the question, the team can pass the chance to rivals.
+        The panel provides this option only at the right moment and ensures it cannot be abused.
+      </p>
+    
+      <h3 class="m-h3">Playing the question: revealing answers and the bank</h3>
+    
+      <p class="m-p">
+        After control is set, the team answers and the operator reveals the correct answers on the board.
+        Each correct answer adds points to the <span class="m-strong">round bank</span>.
+        The bank is visible on the display and grows with each correct answer.
+      </p>
+    
+      <p class="m-p">
+        Gameplay continues until:
+        all answers are revealed,
+        or the team loses three “chances” (three Xs),
+        then the operator ends the stage and moves to the steal (when conditions are met).
+      </p>
+    
+      <h3 class="m-h3">Misses (X) and the 3-second limit</h3>
+    
+      <p class="m-p">
+        A wrong answer is marked with an <span class="m-strong">X</span> on the board.
+        Three errors mean losing control and giving a steal attempt to the opponents.
+        The system also has a <span class="m-strong">3-second</span> time limit for answers —
+        exceeding the limit is treated as a miss (X).
+      </p>
+    
+      <div class="m-note">
+        <b>Why a timer?</b><br/>
+        It’s a “whip for pace.” The timer lets the operator close hesitation quickly
+        without debate and keep the rhythm of the game.
+      </div>
+    
+      <h3 class="m-h3">Stealing the bank (one answer)</h3>
+    
+      <p class="m-p">
+        When the playing team uses three “chances” before revealing all answers,
+        the question passes to the opposing team.
+        The opponents get <span class="m-strong">one answer</span>:
+        if they hit — the bank goes to them,
+        if not — the bank stays with the playing team.
+        This closes the question and the round according to the rules.
+      </p>
+    
+      <h3 class="m-h3">Revealing missing answers and ending the round</h3>
+    
+      <p class="m-p">
+        After the question is resolved the operator can reveal missing answers “for information,”
+        so the audience sees the full board.
+        Then the operator ends the round: the bank is added to the correct team,
+        taking the round multiplier into account.
+      </p>
+    
+      <div class="m-note">
+        <b>Practical note:</b><br/>
+        The panel deliberately separates “playing the question” from “ending the round.”
+        This way the operator doesn’t accidentally clear the board state
+        before the host delivers the punchline or before “thank you” is said.
+      </div>
+
+      <h3 class="m-h3">Ending rounds and moving on</h3>
+      
+      <p class="m-p">
+        After each round the system updates team scores and checks
+        whether the end-of-game condition has been met (set in “Additional settings”).
+        Most often it’s a points threshold, e.g. <span class="m-strong">300</span>,
+        but it can be different — depending on how you want to run the tournament.
+      </p>
+      
+      <p class="m-p">
+        If the final is <span class="m-strong">enabled</span> and the round-end condition is met,
+        the game moves to the final.
+        If the final is <span class="m-strong">disabled</span>, the game ends after rounds
+        and the system goes to the ending screen (logo/points/prize — according to settings).
+      </p>
+      
+      <div class="m-warn">
+        <b>Warning:</b><br/>
+        If the game runs out of questions during play
+        before the points threshold is reached,
+        the system ends rounds due to lack of questions.
+        Then the game moves to the final (if enabled)
+        or to the ending (if the final is disabled).
+      </div>
+    
+    <h3 class="m-h2">4) Final</h3>
+
+      <p class="m-p">
+        The final is a separate game mode. Two contestants
+        from the team that won the main game take part.
+        They answer the same <span class="m-strong">5 questions</span>,
+        and their points are summed. The goal is to reach the final threshold
+        (default <span class="m-strong">200 points</span>, unless set otherwise).
+      </p>
+      
+      <h3 class="m-h3">Final preparation</h3>
+      
+      <p class="m-p">
+        Before starting the final, in game settings you must have selected and confirmed
+        <span class="m-strong">exactly 5 final questions</span>.
+        This ensures the final is ready to run without searching for questions during play.
+      </p>
+      
+      <p class="m-p">
+        The second contestant should not know the first contestant’s answers.
+        In practice, during the first contestant’s turn
+        the second contestant turns away or wears headphones with music.
+      </p>
+      
+      <h3 class="m-h3">Final preparation</h3>
+      
+      <p class="m-p">
+        Before starting the final, in game settings you must have selected and confirmed
+        <span class="m-strong">exactly 5 final questions</span>.
+        This ensures the final is ready to run without searching for questions during play.
+      </p>
+      
+      <p class="m-p">
+        In the final it is very important that the second contestant does not know the first contestant’s answers.
+        Therefore during the first contestant’s round the second contestant
+        <span class="m-strong">moves away and wears headphones with music</span>,
+        so they cannot hear the questions or answers.
+      </p>
+      
+      <h3 class="m-h3">Round 1 – first contestant (15 seconds)</h3>
+      
+      <p class="m-p">
+        The host reads five questions in a row, and the first contestant answers within
+        <span class="m-strong">15 seconds</span>.
+        The operator <span class="m-strong">types the answers</span> in the final panel.
+        At this stage answers are not yet scored or revealed.
+      </p>
+      
+      <p class="m-p">
+        After the round the operator assigns the typed answers to the list of scored results
+        and <span class="m-strong">reveals them on the board</span>.
+        If an answer does not match any item in the list,
+        it receives <span class="m-strong">0 points</span>.
+      </p>
+      
+      <p class="m-p">
+        After revealing the first contestant’s answers, the system hides their half of the board,
+        and the host prepares the entry of the second contestant and reminds the final rules.
+      </p>
+      
+      <h3 class="m-h3">Round 2 – second contestant (20 seconds) and repeats</h3>
+      
+      <p class="m-p">
+        The second contestant returns and answers the same questions within
+        <span class="m-strong">20 seconds</span>.
+        When the half-board with the first contestant’s answers appears,
+        the second contestant <span class="m-strong">turns away</span>
+        so they cannot see them and be influenced.
+      </p>
+      
+      <p class="m-p">
+        The operator again first types all answers of the second contestant,
+        without revealing or scoring them “live.”
+        If the second person gives the same answer as the first,
+        it is a <span class="m-strong">repeat</span> — the contestant must give another answer,
+        and the operator can mark the attempt as repeated.
+        Repeated answers do not score points.
+      </p>
+      
+      <p class="m-p">
+        After the round the operator assigns the second contestant’s answers to the list of scored results
+        and <span class="m-strong">reveals them one by one</span> on the board.
+        The points of both contestants are summed.
+      </p>
+      
+      <h3 class="m-h3">When the final ends</h3>
+      
+      <p class="m-p">
+        The final ends when the total points reach or exceed
+        the set threshold. It can happen that the threshold is reached after the first contestant’s turn
+        — then the second contestant does not need to play, and the game goes straight to the ending.
+      </p>
+      
+      <p class="m-p">
+        After the final the system shows the ending screen according to the game ending settings:
+        <span class="m-strong">logo</span>, <span class="m-strong">points</span> or
+        <span class="m-strong">prize amount</span>.
+      </p>`,
+      demo: `<p class="m-p">
+        In this tab you can restore sample starter materials:
+        a question base, logos, and ready games of different categories and states.
+      </p>
+  
+      <p class="m-p">
+        This is useful when:
+      </p>
+  
+      <ul class="m-ul">
+        <li>you want to quickly see how the system works</li>
+        <li>you are testing features without creating your own data</li>
+        <li>you accidentally removed the sample content</li>
+      </ul>
+  
+      <div class="m-warn">
+        Restoring demo does not remove your data — it only adds sample materials.
+      </div>
+  
+      <div class="m-box">
+        <button class="btn" id="demoRestoreBtn">
+          ↺ Restore demo files
+        </button>
+  
+        <p class="m-p m-muted" style="margin-top:10px">
+          After clicking you will be taken to the My games view and demo will be loaded automatically.
+        </p>
+      </div>`,
+    },
   },
   builderImportExport: {
     defaults: {


### PR DESCRIPTION
### Motivation
- Replace the previously inlined English/Polish manual HTML with a multilingual i18n-driven approach so the manual can be served in Polish, English and Ukrainian from the translation dictionaries. 
- Keep the structural HTML in `manual.html` but move section bodies into the translation files to follow the project's multilingual scheme and avoid duplicated standalone HTML files.

### Description
- Add `data-i18n-html=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698813f5dc748321ab2c0988697f0b1f)