### PR TITLE
Fix SUMA label refresh, account back button, and refresh base-explorer on language change

### DIFF
--- a/account.html
+++ b/account.html
@@ -18,7 +18,7 @@
   <header class="topbar">
     <div class="brand">FAMILIADA</div>
     <div class="right">
-      <button class="btn" href="builder.html" type="button" data-i18n="account.backToGamess">← Moje gry</button>
+      <button class="btn" id="backToGames" type="button" data-i18n="account.backToGames">← Moje gry</button>
     </div>
   </header>
 

--- a/base-explorer/js/page.js
+++ b/base-explorer/js/page.js
@@ -82,6 +82,10 @@ btnLogout?.addEventListener("click", async () => {
     // ===== akcje UI (klik folder, search, selekcja) =====
     const api = wireActions({ state });
 
+    window.addEventListener("i18n:lang", async () => {
+      await api.refreshList();
+    });
+
     // ustaw cache all-questions dla widoku ALL
     state._allQuestions = qs;
     state._viewQuestions = qs;

--- a/display/js/scene.js
+++ b/display/js/scene.js
@@ -730,9 +730,11 @@ export async function createScene() {
   const refreshSumaLabel = () => {
     SUMA_LABEL = t("display.sumLabel");
     if (bigMode === "ROUNDS") {
-      redrawRounds();
+      const F = roundsSumaFields();
+      writeField(GLYPHS, big, F.label, SUMA_LABEL, LIT.main);
     } else if (bigMode === "FINAL") {
-      drawFinalSum();
+      const labelField = finalState.sumMode === "A" ? FINAL.sumaALabel : FINAL.sumaBLabel;
+      writeField(GLYPHS, big, labelField, SUMA_LABEL, LIT.main);
     }
   };
 

--- a/js/pages/account.js
+++ b/js/pages/account.js
@@ -15,9 +15,14 @@ const saveUsername = document.getElementById("saveUsername");
 const saveEmail = document.getElementById("saveEmail");
 const savePass = document.getElementById("savePass");
 const deleteAccount = document.getElementById("deleteAccount");
+const backToGames = document.getElementById("backToGames");
 
 function setStatus(m = "") { if (status) status.textContent = m; }
 function setErr(m = "") { if (err) err.textContent = m; }
+
+backToGames?.addEventListener("click", () => {
+  location.href = withLangParam("builder.html");
+});
 
 async function ensureUsernameAvailable(username, userId) {
   const { data, error } = await sb()


### PR DESCRIPTION
### Motivation
- Prevent full redraws of the SUMA area when only the localized label changes to avoid overwriting or disturbing current SUMA value and layout.
- Make the account page back button usable from JS by giving it an `id` and wiring navigation, and ensure the translation key is used correctly.
- Ensure the Base Explorer updates its view when the UI language changes so translations are applied to the list/tree without manual reload.

### Description
- Update `display/js/scene.js` so `refreshSumaLabel` only rewrites the SUMA label field in `ROUNDS` and `FINAL` modes using `writeField` instead of calling full redraw functions. (changes in `refreshSumaLabel` logic)
- Add `id="backToGames"` to the back button in `account.html` and wire it in `js/pages/account.js` to navigate to `builder.html` while preserving language via `withLangParam("builder.html")`.
- Add a language change listener in `base-explorer/js/page.js` that calls the explorer API `refreshList` on `i18n:lang` events so the list/tree re-renders with updated translations.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69886ddbd2908321a5f8d7ca107af654)