### PR TITLE
i18n: make auth emails respect UI language; localize modals, text-pix system font and refresh host texts on language change

### DIFF
--- a/control/js/gameFinal.js
+++ b/control/js/gameFinal.js
@@ -595,6 +595,15 @@ export function createFinal({ ui, store, devices, display, loadAnswers }) {
     hostClearRight();
   }
 
+  function refreshHostTranslations() {
+    hostLastLeft = null;
+    hostLastRight = null;
+    hostLastTitleSecond = null;
+    hostUpdate();
+  }
+
+  window.addEventListener("i18n:lang", refreshHostTranslations);
+
   // ---------------- TIMER ----------------
   async function displaySetTimerSeconds(sec) {
     const txt = String(Math.max(0, sec));

--- a/control/js/gameRounds.js
+++ b/control/js/gameRounds.js
@@ -139,6 +139,12 @@ function hostUpdate() {
 }
 // ==================================================
 
+  function refreshHostTranslations() {
+    hostUpdate();
+  }
+
+  window.addEventListener("i18n:lang", refreshHostTranslations);
+
 
   function emit() {
     try {

--- a/js/core/auth.js
+++ b/js/core/auth.js
@@ -161,10 +161,22 @@ export async function signOut() {
   _unameCache = { userId: null, username: null, ts: 0 };
 }
 
-export async function resetPassword(loginOrEmail, redirectTo) {
+export async function resetPassword(loginOrEmail, redirectTo, language) {
   const email = await loginToEmail(loginOrEmail);
   if (!email) throw new Error(t("index.errResetMissingLogin"));
 
-  const { error } = await sb().auth.resetPasswordForEmail(email, { redirectTo });
+  const options = { redirectTo };
+  if (language) options.data = { language };
+  const { error } = await sb().auth.resetPasswordForEmail(email, options);
   if (error) throw new Error(niceAuthError(error));
+}
+
+export async function updateUserLanguage(language) {
+  if (!language) return;
+  try {
+    const { error } = await sb().auth.updateUser({ data: { language } });
+    if (error) console.warn("[auth] updateUserLanguage failed:", error);
+  } catch (e) {
+    console.warn("[auth] updateUserLanguage failed:", e);
+  }
 }

--- a/js/core/modal.js
+++ b/js/core/modal.js
@@ -1,5 +1,9 @@
 let modalSeq = 0;
 
+function modalText(key, fallback) {
+  return typeof t === "function" ? t(key) : fallback;
+}
+
 function buildModal({
   title,
   text,
@@ -33,7 +37,7 @@ function buildModal({
   const closeBtn = document.createElement("button");
   closeBtn.className = "btn sm";
   closeBtn.type = "button";
-  closeBtn.setAttribute("aria-label", "Zamknij");
+  closeBtn.setAttribute("aria-label", modalText("common.modal.closeLabel", "Zamknij"));
   closeBtn.textContent = "✕";
 
   head.appendChild(titleEl);
@@ -86,20 +90,30 @@ function buildModal({
 }
 
 function openModal({
-  title = "Potwierdź",
-  text = "Na pewno?",
-  okText = "Tak",
-  cancelText = "Nie",
+  title,
+  text,
+  okText,
+  cancelText,
   showCancel = true,
   body = null,
   initialFocus = null,
 } = {}) {
   return new Promise((resolve) => {
+    const fallbackTitle = showCancel
+      ? modalText("common.modal.confirmTitle", "Potwierdź")
+      : modalText("common.modal.alertTitle", "Informacja");
+    const fallbackText = showCancel
+      ? modalText("common.modal.confirmText", "Na pewno?")
+      : "—";
+    const fallbackOk = showCancel
+      ? modalText("common.modal.confirmOk", "Tak")
+      : modalText("common.modal.alertOk", "OK");
+    const fallbackCancel = modalText("common.modal.confirmCancel", "Nie");
     const { overlay, okBtn, cancelBtn, closeBtn } = buildModal({
-      title,
-      text,
-      okText,
-      cancelText,
+      title: title ?? fallbackTitle,
+      text: text ?? fallbackText,
+      okText: okText ?? fallbackOk,
+      cancelText: cancelText ?? fallbackCancel,
       showCancel,
       body,
     });
@@ -136,19 +150,30 @@ function openModal({
   });
 }
 
-export function confirmModal({ title = "Potwierdź", text = "Na pewno?", okText = "Tak", cancelText = "Nie" } = {}) {
-  return openModal({ title, text, okText, cancelText, showCancel: true });
+export function confirmModal({ title, text, okText, cancelText } = {}) {
+  return openModal({
+    title: title ?? modalText("common.modal.confirmTitle", "Potwierdź"),
+    text: text ?? modalText("common.modal.confirmText", "Na pewno?"),
+    okText: okText ?? modalText("common.modal.confirmOk", "Tak"),
+    cancelText: cancelText ?? modalText("common.modal.confirmCancel", "Nie"),
+    showCancel: true,
+  });
 }
 
-export function alertModal({ title = "Informacja", text = "—", okText = "OK" } = {}) {
-  return openModal({ title, text, okText, showCancel: false });
+export function alertModal({ title, text, okText } = {}) {
+  return openModal({
+    title: title ?? modalText("common.modal.alertTitle", "Informacja"),
+    text: text ?? "—",
+    okText: okText ?? modalText("common.modal.alertOk", "OK"),
+    showCancel: false,
+  });
 }
 
 export function promptModal({
-  title = "Wpisz",
-  text = "Podaj wartość:",
-  okText = "Zapisz",
-  cancelText = "Anuluj",
+  title,
+  text,
+  okText,
+  cancelText,
   value = "",
   placeholder = "",
 } = {}) {
@@ -159,10 +184,10 @@ export function promptModal({
   input.placeholder = placeholder;
 
   return openModal({
-    title,
-    text,
-    okText,
-    cancelText,
+    title: title ?? modalText("common.modal.promptTitle", "Wpisz"),
+    text: text ?? modalText("common.modal.promptText", "Podaj wartość:"),
+    okText: okText ?? modalText("common.modal.promptOk", "Zapisz"),
+    cancelText: cancelText ?? modalText("common.modal.promptCancel", "Anuluj"),
     showCancel: true,
     body: input,
     initialFocus: input,

--- a/js/pages/account.js
+++ b/js/pages/account.js
@@ -1,5 +1,5 @@
 import { sb } from "../core/supabase.js";
-import { requireAuth, validatePassword, validateUsername, signOut } from "../core/auth.js";
+import { requireAuth, updateUserLanguage, validatePassword, validateUsername, signOut } from "../core/auth.js";
 import { initI18n, t, getUiLang, withLangParam } from "../../translation/translation.js";
 
 const status = document.getElementById("status");
@@ -41,6 +41,7 @@ let currentEmail = "";
 async function loadProfile() {
   const user = await requireAuth("index.html?setup=username");
   if (!user) return;
+  await updateUserLanguage(getUiLang());
   usernameInput.value = user.username || "";
   emailInput.value = user.email || "";
   currentEmail = user.email || "";

--- a/js/pages/confirm.js
+++ b/js/pages/confirm.js
@@ -1,5 +1,6 @@
 import { sb } from "../core/supabase.js";
-import { initI18n, t } from "../../translation/translation.js";
+import { updateUserLanguage } from "../core/auth.js";
+import { initI18n, t, getUiLang } from "../../translation/translation.js";
 
 const status = document.getElementById("status");
 const err = document.getElementById("err");
@@ -38,6 +39,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   try {
     const { data } = await sb().auth.getSession();
     if (data?.session?.user) {
+      await updateUserLanguage(getUiLang());
       sessionInfo = t("confirm.sessionInfo");
       setErr("");
     }
@@ -89,6 +91,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         const { data, error } = await sb().auth.verifyOtp({ token_hash: tokenHash, type: otpType });
         if (error) throw error;
         if (data?.session) {
+          await updateUserLanguage(getUiLang());
           await syncProfileEmail(data.session.user);
           setStatus(t("confirm.done"));
           go.style.display = "inline-flex";
@@ -113,6 +116,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         if (error) throw error;
 
         if (data?.session) {
+          await updateUserLanguage(getUiLang());
           await syncProfileEmail(data.session.user);
           setStatus(t("confirm.done"));
           go.style.display = "inline-flex";
@@ -144,6 +148,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (error) throw error;
 
     if (data?.session) {
+      await updateUserLanguage(getUiLang());
       await syncProfileEmail(data.session.user);
       setStatus(t("confirm.done"));
       go.style.display = "inline-flex";

--- a/js/pages/index.js
+++ b/js/pages/index.js
@@ -1,5 +1,5 @@
 // js/pages/index.js
-import { getUser, signIn, signUp, resetPassword, validatePassword, validateUsername } from "../core/auth.js";
+import { getUser, signIn, signUp, resetPassword, updateUserLanguage, validatePassword, validateUsername } from "../core/auth.js";
 import { sb } from "../core/supabase.js";
 import { initI18n, t, getUiLang, withLangParam } from "../../translation/translation.js";
 
@@ -117,6 +117,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   const u = await getUser();
   if (u) {
+    await updateUserLanguage(getUiLang());
     if (!u.username || setup === "username") {
       openUsernameSetup();
     } else if (nextTarget === "polls-hub") {
@@ -168,6 +169,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         await signIn(loginOrEmail, pwd); // <-- może być username
         clearPendingEmailChange();
         const authed = await getUser();
+        await updateUserLanguage(getUiLang());
         if (!authed?.username) {
           openUsernameSetup();
         } else if (nextTarget === "polls-hub") {
@@ -191,7 +193,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     try {
       setStatus(t("index.statusResetSending"));
       const redirectTo = withLangParam(new URL("reset.html", location.href).toString());
-      await resetPassword(loginOrEmail, redirectTo);
+      await resetPassword(loginOrEmail, redirectTo, getUiLang());
       setStatus(t("index.statusResetSent"));
     } catch (e) {
       console.error(e);

--- a/js/pages/reset.js
+++ b/js/pages/reset.js
@@ -1,6 +1,6 @@
 import { sb } from "../core/supabase.js";
-import { validatePassword } from "../core/auth.js";
-import { initI18n, t } from "../../translation/translation.js";
+import { updateUserLanguage, validatePassword } from "../core/auth.js";
+import { initI18n, t, getUiLang } from "../../translation/translation.js";
 
 const status = document.getElementById("status");
 const err = document.getElementById("err");
@@ -66,6 +66,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       return;
     }
 
+    await updateUserLanguage(getUiLang());
     setStatus(t("reset.linkOk"));
     form.style.display = "grid";
   } catch(e){

--- a/logo-editor/js/text-pix.js
+++ b/logo-editor/js/text-pix.js
@@ -169,6 +169,14 @@ export function initTextPixEditor(ctx) {
       if (!Array.isArray(data)) {
         throw new Error(t("logoEditor.textPix.errors.fontsInvalid"));
       }
+
+      const systemLabel = t("logoEditor.textPix.systemFont");
+      for (const font of data) {
+        if (!font || !font.value) continue;
+        if (String(font.value).includes("system-ui")) {
+          font.label = systemLabel;
+        }
+      }
   
       SYSTEM_FONTS = data;
       return SYSTEM_FONTS;

--- a/polls-hub.html
+++ b/polls-hub.html
@@ -70,7 +70,6 @@
               <section class="hub-col">
                 <div class="hub-col-head">
                   <div>
-                    <div class="hub-col-title">Moje sondaże</div>
                     <div class="hub-col-title" data-i18n="pollsHub.sections.myPolls">Moje sondaże</div>
                     <div class="hub-col-hint" data-i18n="pollsHub.sections.selectHint">Kliknij kafelek, aby go zaznaczyć.</div>
                   </div>

--- a/translation/en.js
+++ b/translation/en.js
@@ -15,6 +15,19 @@ const en = {
     open: "Open",
     copy: "Copy",
     done: "Done",
+    modal: {
+      confirmTitle: "Confirm",
+      confirmText: "Are you sure?",
+      confirmOk: "Yes",
+      confirmCancel: "No",
+      alertTitle: "Information",
+      alertOk: "OK",
+      promptTitle: "Enter",
+      promptText: "Provide a value:",
+      promptOk: "Save",
+      promptCancel: "Cancel",
+      closeLabel: "Close",
+    },
     fullscreen: "Fullscreen",
     a2hsTitle: "Fullscreen on iPhone",
     a2hsHost:
@@ -2752,6 +2765,7 @@ const en = {
     },
     textPix: {
       font: "Font",
+      systemFont: "System",
       searchPlaceholder: "Search fonts…",
       searchClear: "Clear",
       emptyResults: "No results",

--- a/translation/pl.js
+++ b/translation/pl.js
@@ -15,6 +15,19 @@ const pl = {
     open: "Otwórz",
     copy: "Kopiuj",
     done: "Gotowe",
+    modal: {
+      confirmTitle: "Potwierdź",
+      confirmText: "Na pewno?",
+      confirmOk: "Tak",
+      confirmCancel: "Nie",
+      alertTitle: "Informacja",
+      alertOk: "OK",
+      promptTitle: "Wpisz",
+      promptText: "Podaj wartość:",
+      promptOk: "Zapisz",
+      promptCancel: "Anuluj",
+      closeLabel: "Zamknij",
+    },
     fullscreen: "Pełny ekran",
     a2hsTitle: "Pełny ekran na iPhone",
     a2hsHost:
@@ -2758,6 +2771,7 @@ const pl = {
     },
     textPix: {
       font: "Czcionka",
+      systemFont: "Systemowa",
       searchPlaceholder: "Szukaj czcionki…",
       searchClear: "Wyczyść",
       emptyResults: "Brak wyników",

--- a/translation/uk.js
+++ b/translation/uk.js
@@ -15,6 +15,19 @@ const uk = {
     open: "Відкрити",
     copy: "Копіювати",
     done: "Готово",
+    modal: {
+      confirmTitle: "Підтвердити",
+      confirmText: "Ви впевнені?",
+      confirmOk: "Так",
+      confirmCancel: "Ні",
+      alertTitle: "Інформація",
+      alertOk: "OK",
+      promptTitle: "Введіть",
+      promptText: "Вкажіть значення:",
+      promptOk: "Зберегти",
+      promptCancel: "Скасувати",
+      closeLabel: "Закрити",
+    },
     fullscreen: "На весь екран",
     a2hsTitle: "Повний екран на iPhone",
     a2hsHost:
@@ -2755,6 +2768,7 @@ const uk = {
     },
     textPix: {
       font: "Шрифт",
+      systemFont: "Системна",
       searchPlaceholder: "Пошук шрифту…",
       searchClear: "Очистити",
       emptyResults: "Немає результатів",


### PR DESCRIPTION
### Motivation
- Ensure emails sent by auth flows (confirm/reset) use the current UI language and keep user language metadata in sync so Supabase templates render in the expected language. 
- Localize modal labels/buttons and the Text Pix "system" font label so UI elements follow translations. 
- Refresh host-side displayed texts immediately when the UI language changes to avoid stale untranslated labels.

### Description
- Pass UI language to password reset requests by extending `resetPassword` with a `language` parameter and including it in the Supabase call, and add `updateUserLanguage(language)` in `js/core/auth.js` to update user metadata. 
- Call `updateUserLanguage(getUiLang())` in auth-related pages so the user metadata is updated after login/confirmation/reset/account operations (`js/pages/index.js`, `js/pages/confirm.js`, `js/pages/reset.js`, `js/pages/account.js`). 
- Localize modal defaults by adding a `modalText()` helper and wiring translation fallbacks in `js/core/modal.js`, and add `common.modal.*` keys to `translation/en.js`, `translation/pl.js` and `translation/uk.js`. 
- Localize the Text Pix system font label by mapping any font whose `value` includes `system-ui` to `t("logoEditor.textPix.systemFont")` when loading `logo-editor/js/fonts.json` in `logo-editor/js/text-pix.js`, and add `textPix.systemFont` keys to the translations. 
- Remove duplicated static header in `polls-hub.html` so the visible title is rendered from the `data-i18n` attribute only. 
- Add `i18n:lang` listeners and small refresh helpers in `control/js/gameRounds.js` and `control/js/gameFinal.js` so host messages are refreshed immediately when language changes.

### Testing
- A local HTTP server was started (`python -m http.server 8000`) and a Playwright script was used to open `/logo-editor/logo-editor.html` and interact with the UI; the script completed and produced `artifacts/logo-editor-fonts.png` (screenshot artifact created successfully). 
- No automated tests were run for the recent auth language metadata changes (no unit tests or integration tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698879dd848c8321b2cf26927d34a41a)