### PR TITLE
Pass email-change target via redirect and update send-email hook to handle email_change

### DIFF
--- a/js/pages/account.js
+++ b/js/pages/account.js
@@ -79,7 +79,9 @@ async function handleEmailSave() {
     const mail = String(emailInput.value || "").trim().toLowerCase();
     if (!mail || !mail.includes("@")) throw new Error(t("account.errInvalidEmail"));
 
-    const redirectTo = withLangParam(new URL("confirm.html", location.href).toString());
+    const confirmUrl = new URL("confirm.html", location.href);
+    confirmUrl.searchParams.set("to", mail);
+    const redirectTo = withLangParam(confirmUrl.toString());
     const language = getUiLang();
     const { data, error } = await sb().auth.updateUser(
       { email: mail, data: { language } },
@@ -95,18 +97,7 @@ async function handleEmailSave() {
       if (profileError) throw profileError;
     }
 
-    if (currentEmail) {
-      localStorage.setItem("pendingEmailChange", JSON.stringify({
-        old: currentEmail,
-        next: mail,
-        ts: Date.now(),
-      }));
-    }
     setStatus(t("account.statusEmailSaved"));
-    await signOut();
-    setTimeout(() => {
-      location.href = withLangParam("index.html");
-    }, 400);
   } catch (e) {
     console.error(e);
     setErr(e?.message || String(e));
@@ -169,4 +160,34 @@ document.addEventListener("DOMContentLoaded", () => {
   saveEmail?.addEventListener("click", handleEmailSave);
   savePass?.addEventListener("click", handlePassSave);
   deleteAccount?.addEventListener("click", handleDeleteAccount);
+
+  usernameInput?.addEventListener("keydown", (e) => {
+    if (e.key !== "Enter") return;
+    e.preventDefault();
+    saveUsername?.click();
+  });
+
+  emailInput?.addEventListener("keydown", (e) => {
+    if (e.key !== "Enter") return;
+    e.preventDefault();
+    saveEmail?.click();
+  });
+
+  pass1?.addEventListener("keydown", (e) => {
+    if (e.key !== "Enter") return;
+    e.preventDefault();
+    pass2?.focus();
+  });
+
+  pass2?.addEventListener("keydown", (e) => {
+    if (e.key !== "Enter") return;
+    e.preventDefault();
+    savePass?.click();
+  });
+
+  deletePassword?.addEventListener("keydown", (e) => {
+    if (e.key !== "Enter") return;
+    e.preventDefault();
+    deleteAccount?.click();
+  });
 });

--- a/js/pages/index.js
+++ b/js/pages/index.js
@@ -41,19 +41,6 @@ function setErr(m = "") { err.textContent = m; }
 function setStatus(m = "") { status.textContent = m; }
 function setUsernameErr(m = "") { if (usernameErr) usernameErr.textContent = m; }
 
-function getPendingEmailChange() {
-  try {
-    const raw = localStorage.getItem("pendingEmailChange");
-    return raw ? JSON.parse(raw) : null;
-  } catch {
-    return null;
-  }
-}
-
-function clearPendingEmailChange() {
-  localStorage.removeItem("pendingEmailChange");
-}
-
 function openUsernameSetup() {
   if (loginCard) loginCard.hidden = true;
   if (setupCard) setupCard.hidden = false;
@@ -149,12 +136,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     const pwd = pass.value;
 
     if (!loginOrEmail || !pwd) return setErr(t("index.errMissingLogin"));
-    if (loginOrEmail.includes("@")) {
-      const pending = getPendingEmailChange();
-      if (pending?.old && String(pending.old).toLowerCase() === loginOrEmail.toLowerCase()) {
-        return setErr(t("index.errPendingEmailChange"));
-      }
-    }
 
     try {
       if (mode === "register") {
@@ -176,7 +157,6 @@ document.addEventListener("DOMContentLoaded", async () => {
       } else {
         setStatus(t("index.statusLoggingIn"));
         await signIn(loginOrEmail, pwd); // <-- może być username
-        clearPendingEmailChange();
         const authed = await getUser();
         await syncLanguage();
         if (!authed?.username) {
@@ -214,5 +194,27 @@ document.addEventListener("DOMContentLoaded", async () => {
   btnUsernameSave?.addEventListener("click", saveUsername);
   usernameFirst?.addEventListener("keydown", (e) => {
     if (e.key === "Enter") saveUsername();
+  });
+
+  email?.addEventListener("keydown", (e) => {
+    if (e.key !== "Enter") return;
+    e.preventDefault();
+    pass?.focus();
+  });
+
+  pass?.addEventListener("keydown", (e) => {
+    if (e.key !== "Enter") return;
+    e.preventDefault();
+    if (mode === "register") {
+      pass2?.focus();
+    } else {
+      btnPrimary?.click();
+    }
+  });
+
+  pass2?.addEventListener("keydown", (e) => {
+    if (e.key !== "Enter") return;
+    e.preventDefault();
+    btnPrimary?.click();
   });
 });

--- a/js/pages/reset.js
+++ b/js/pages/reset.js
@@ -112,4 +112,16 @@ document.addEventListener("DOMContentLoaded", async () => {
       setErr(e?.message || String(e));
     }
   });
+
+  p1?.addEventListener("keydown", (e) => {
+    if (e.key !== "Enter") return;
+    e.preventDefault();
+    p2?.focus();
+  });
+
+  p2?.addEventListener("keydown", (e) => {
+    if (e.key !== "Enter") return;
+    e.preventDefault();
+    save?.click();
+  });
 });


### PR DESCRIPTION
### Motivation
- Supabase `email_change` webhooks can omit `user.email_new` and use inconsistent token fields, so we need a reliable way to target the new address when confirming email changes. 
- The previous client-side `pendingEmailChange` approach was fragile and blocked some logins, and form UX lacked convenient Enter-key navigation. 
- The hook should robustly map tokens and send confirmations to both old and new addresses when possible.

### Description
- Updated `js/pages/account.js` to include the target email as a `to` query parameter on the confirm URL (`confirmUrl.searchParams.set("to", mail)`), removed the `localStorage.pendingEmailChange` flow and forced sign-out, and added Enter-key handlers for account form fields. 
- Updated `js/pages/index.js` and `js/pages/reset.js` to remove pending-email-change checks and add Enter-to-next-field / Enter-to-submit keyboard handlers to improve form navigation. 
- Reworked `supabase/functions/send-email/index.ts` by adding `json()` and `sendEmail()` helpers, returning JSON error responses, adding debug logs, updating `buildActionLink()` / `renderHtml()` / `subjectFor()` to handle `email_change` consistently, and adding a special `email_change` branch that reads the new address from `email_data.redirect_to?to=`, maps `token_hash` / `token_hash_new` with safe fallbacks, and sends confirmations to the current and target addresses when available. 

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988ab94bca08321a2e7d44e448961b6)