### PR TITLE
Fix mobile topbar placement and poll tab corners

### DIFF
--- a/css/builder.css
+++ b/css/builder.css
@@ -506,6 +506,22 @@ body.builder-body > main.wrap{
   padding: 6px 0;
 }
 
+@media (max-width: 980px){
+  body.builder-body .user-btn .user-sub{
+    padding-left: 10px;
+    font-size: 13px;
+    font-weight: 800;
+  }
+
+  body.builder-body .user-btn .user-sub::before{
+    display: block;
+  }
+
+  body.builder-body .user-btn .user-sub::after{
+    content: none;
+  }
+}
+
 /* =========================================================
    MOBILE
 ========================================================= */

--- a/css/polls-hub.css
+++ b/css/polls-hub.css
@@ -49,6 +49,122 @@ body.polls-hub-body .bar{
 ========================================================= */
 
 .tabs-card.hub-tabs{
+  --tab-height: 48px;
+  --tab-extra: 1px;
+  --radius: 12px;
+  --corner-bottom: 0px;
+  --corner-shift: 1px;
+  --border-fudge: 2px;
+  --surface: #111827;
+  --border-color: var(--line2);
+}
+
+.hub-tabs .tabs-strip{
+  position: relative;
+  z-index: 1;
+}
+
+.hub-tabs .tab-slot,
+.hub-tabs .tab-label{
+  position: relative;
+  display: flex;
+  justify-content: center;
+}
+
+.hub-tabs .tab-slot{
+  min-width: 0;
+  flex: 1 1 0;
+  align-items: stretch;
+}
+
+.hub-tabs .tab-label{
+  width: 100%;
+  min-height: var(--tab-height);
+  border: 0;
+  background: transparent;
+  color: rgba(255,255,255,.72);
+  cursor: pointer;
+  align-items: center;
+}
+
+.hub-tabs .tab-label.active{ color: #f9fafb; }
+
+.hub-tabs .tab-wrapper{
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  pointer-events: none;
+  z-index: 2;
+  display: none;
+}
+
+.hub-tabs .tab-slot:has(.tab-label.active) .tab-wrapper{
+  display: block;
+}
+
+.hub-tabs .tab-active,
+.hub-tabs .tab-corner::before{
+  border: 1px solid var(--border-color);
+}
+
+.hub-tabs .tab-active{
+  height: calc(var(--tab-height) + var(--tab-extra));
+  width: 100%;
+  line-height: var(--tab-height);
+  text-align: center;
+  background: var(--surface);
+  border-bottom: none;
+  border-top-left-radius: var(--radius);
+  border-top-right-radius: var(--radius);
+  color: #f9fafb;
+  position: relative;
+  z-index: 2;
+}
+
+.hub-tabs .tab-corner{
+  position: absolute;
+  bottom: var(--corner-bottom);
+  width: var(--radius);
+  height: var(--radius);
+  overflow: hidden;
+  background-color: transparent;
+  z-index: 3;
+  pointer-events: none;
+}
+
+.hub-tabs .tab-corner-left{
+  left: 0;
+  transform: translateX(calc(-100% + var(--corner-shift)));
+  background-image: radial-gradient(circle at 0% 0%, transparent var(--radius), var(--surface) var(--radius));
+}
+
+.hub-tabs .tab-corner-right{
+  right: 0;
+  transform: translateX(calc(100% - var(--corner-shift)));
+  background-image: radial-gradient(circle at 100% 0%, transparent var(--radius), var(--surface) var(--radius));
+}
+
+.hub-tabs .tab-corner::before{
+  content: "";
+  position: absolute;
+  width: calc(2 * var(--radius));
+  height: calc(2 * var(--radius));
+  border-radius: 50%;
+  background: transparent;
+}
+
+.hub-tabs .tab-corner-left::before{
+  top: calc(-1 * var(--radius) - var(--border-fudge));
+  left: calc(-1 * var(--radius) - var(--border-fudge));
+}
+
+.hub-tabs .tab-corner-right::before{
+  top: calc(-1 * var(--radius) - var(--border-fudge));
+  right: calc(-1 * var(--radius) - var(--border-fudge));
+}
+
+.tabs-card.hub-tabs{
   flex: 1 1 auto;
   min-height: 0;
   display: flex;
@@ -564,7 +680,7 @@ body.polls-hub-body .bar{
 
 
 .hub-tabs-mobile .tab-slot{ min-width: 0; }
-.hub-tabs-mobile .tab-wrapper{ overflow: hidden; }
+.hub-tabs-mobile .tab-wrapper{ overflow: visible; }
 .hub-tabs-mobile:has(.tab-slot:first-child .tab-label.active) .hub-card{ border-top-left-radius: 0; }
 .hub-tabs-mobile:has(.tab-slot:last-child .tab-label.active) .hub-card{ border-top-right-radius: 0; }
 .hub-tabs-mobile:has(.tab-slot:first-child .tab-label.active) .tab-slot:first-child .tab-corner-left,

--- a/js/core/topbar-mobile-menu.js
+++ b/js/core/topbar-mobile-menu.js
@@ -16,6 +16,7 @@ function initMobileTopbarMenu() {
   const section4Placeholder = document.createComment('topbar-section-4-restore');
   const tabsPlaceholder = document.createComment('topbar-tabs-restore');
   const simpleTabs = document.querySelector('.simple-tabs');
+  const menuItemSelector = 'button, a, .btn, [role="button"], [role="tab"], .who, .user-btn, .lang-switcher, .top-status';
 
   let overlay;
   let panel;
@@ -26,6 +27,13 @@ function initMobileTopbarMenu() {
   let group4;
   let toggleBtn;
   let isMobileMounted = false;
+
+  const hasMenuContent = () => {
+    const hasTabs = !!simpleTabs?.querySelector('.tab, button, [role="tab"]');
+    const hasSection2Items = !!section2.querySelector(menuItemSelector);
+    const hasSection4Items = !!section4.querySelector(menuItemSelector);
+    return hasTabs || hasSection2Items || hasSection4Items;
+  };
 
   const close = () => {
     overlay?.classList.remove('is-open');
@@ -39,6 +47,7 @@ function initMobileTopbarMenu() {
 
   const mountMobile = () => {
     if (isMobileMounted) return;
+    if (!hasMenuContent()) return;
     isMobileMounted = true;
 
     overlay = document.createElement('div');
@@ -94,7 +103,7 @@ function initMobileTopbarMenu() {
     toggleBtn.type = 'button';
     toggleBtn.className = 'btn topbar-menu-toggle';
     toggleBtn.textContent = '☰';
-    section3.prepend(toggleBtn);
+    section3.append(toggleBtn);
 
     toggleBtn.addEventListener('click', open);
     closeBtn.addEventListener('click', close);


### PR DESCRIPTION
### Motivation
- Ensure the mobile topbar menu toggle (`☰`) is always at the far right of the topbar and not inserted before other controls. 
- Hide the mobile menu toggle when there is no movable menu content (no tabs or section controls) so an empty toggle doesn't appear. 
- Make the account/user button presentation in the `builder` mobile view match the desktop appearance (keep text + separator instead of replacing with only a pencil). 
- Restore the tab protrusion / corner visuals in `polls-hub` (and ensure mobile tab corners are not clipped). 

### Description
- Added a `menuItemSelector` and `hasMenuContent()` guard to `js/core/topbar-mobile-menu.js` and skip mounting the mobile panel when there are no tabs or section items. 
- Changed toggle insertion from `section3.prepend(toggleBtn)` to `section3.append(toggleBtn)` so the toggle appears as the last element in section 3 (right-most). 
- Added a mobile-specific rule in `css/builder.css` to preserve the account button `user-sub` text and separator on mobile by overriding the compact pencil-only behavior. 
- Ported builder tab/corner styling into `css/polls-hub.css` (rules for `.hub-tabs .tab-wrapper`, `.tab-active`, `.tab-corner*`, etc.) and changed `.hub-tabs-mobile .tab-wrapper` to `overflow: visible` to avoid clipping the corner protrusions. 

### Testing
- Ran `git diff --check` to validate whitespace/errors and it reported no issues. 
- Ran `node --check js/core/topbar-mobile-menu.js` to validate JS syntax and it succeeded. 
- Launched a local HTTP server and captured Playwright screenshots of mobile `builder.html` and `polls-hub.html` to visually smoke-check the mobile topbar and tab corners, and screenshots were produced successfully. 
- All automated checks listed above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990af733ed0832189c694c8c324acc5)