### PR TITLE
Fix mobile question editor scrolling in portrait vs landscape

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -602,14 +602,35 @@ body.editor-body .rightPanel {
     }
 }
 
-@media (max-width:720px) {
+@media (max-width:720px) and (orientation: portrait) {
+    body.editor-body {
+        overflow: hidden;
+    }
+
+    body.editor-body .wrap {
+        height: calc(100dvh - 72px);
+        overflow: hidden;
+    }
+
+    body.editor-body .left,
+    body.editor-body .rightPanel {
+        overflow: auto;
+    }
+
+    body.editor-body .list,
+    body.editor-body .alist {
+        overflow: auto;
+    }
+}
+
+@media (max-width:720px) and (orientation: landscape) {
+    body.editor-body {
+        overflow: auto;
+    }
+
     body.editor-body .wrap {
         height: auto;
         overflow: visible;
-    }
-
-    body.editor-body {
-        overflow: auto;
     }
 
     body.editor-body .left,
@@ -621,18 +642,6 @@ body.editor-body .rightPanel {
     body.editor-body .list,
     body.editor-body .alist {
         max-height: none;
-        overflow: visible;
-    }
-}
-
-@media (max-width:720px) and (orientation: portrait) {
-    body.editor-body .wrap {
-        height: auto;
-        overflow: visible;
-    }
-
-    body.editor-body .left,
-    body.editor-body .rightPanel {
         overflow: visible;
     }
 }


### PR DESCRIPTION
### Motivation
- The mobile question editor had inverted scrolling behavior: page-level scroll in portrait and inner-card scroll in landscape, which made the editor awkward on phones.
- The intent is to make portrait use internal scrolling inside panels/cards and landscape allow the cards to expand while the page scrolls.

### Description
- Updated `css/editor.css` to add orientation-specific media queries and move/adjust overflow rules to enforce different behavior for portrait and landscape.
- In portrait (`@media (max-width:720px) and (orientation: portrait)`), set `body` to `overflow: hidden`, set `.wrap` height to `calc(100dvh - 72px)`, and enable `overflow: auto` on `.left`, `.rightPanel`, `.list`, and `.alist` so panels scroll internally.
- In landscape (`@media (max-width:720px) and (orientation: landscape)`), restore page-level scrolling with `body { overflow: auto }`, `wrap` set to `height: auto`, and panels set to `overflow: visible` with `max-height: none` so cards expand with content.
- Switched portrait height handling to use `100dvh` to better match mobile viewport behavior.

### Testing
- Ran `git diff --check` which reported no issues and succeeded.
- Served the app with `python3 -m http.server 4173` and captured a mobile portrait screenshot using Playwright, which confirmed the portrait layout and internal panel scrolling (artifact captured as `artifacts/editor-mobile-portrait-layout.png`).
- Performed a visual validation of landscape vs portrait by toggling orientation in Playwright and observed expected scroll behavior for both orientations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699274f578b4832191c77180d99dd351)