### PR TITLE
Fix mobile editor scrolling: pin import/hint in portrait and allow panel expansion in landscape

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -602,18 +602,51 @@ body.editor-body .rightPanel {
     }
 }
 
-@media (max-width:720px) {
-    body.editor-body .wrap {
-        height: auto;
-        overflow: visible;
+@media (max-width:720px) and (orientation: portrait) {
+    body.editor-body {
+        overflow: hidden;
     }
 
+    body.editor-body .wrap {
+        height: calc(100dvh - 72px);
+        overflow: hidden;
+    }
+
+    body.editor-body .left {
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+    }
+
+    body.editor-body .left .list {
+        flex: 1 1 auto;
+        min-height: 0;
+        max-height: none;
+        overflow: auto;
+    }
+
+    body.editor-body .left .hint,
+    body.editor-body .left .row {
+        flex: 0 0 auto;
+    }
+
+    body.editor-body .rightPanel,
+    body.editor-body .alist {
+        overflow: auto;
+    }
+}
+
+@media (max-width:720px) and (orientation: landscape) {
     body.editor-body {
         overflow: auto;
     }
 
+    body.editor-body .wrap,
+    body.editor-body .layout,
     body.editor-body .left,
     body.editor-body .rightPanel {
+        height: auto;
+        min-height: auto;
         max-height: none;
         overflow: visible;
     }
@@ -621,18 +654,6 @@ body.editor-body .rightPanel {
     body.editor-body .list,
     body.editor-body .alist {
         max-height: none;
-        overflow: visible;
-    }
-}
-
-@media (max-width:720px) and (orientation: portrait) {
-    body.editor-body .wrap {
-        height: auto;
-        overflow: visible;
-    }
-
-    body.editor-body .left,
-    body.editor-body .rightPanel {
         overflow: visible;
     }
 }


### PR DESCRIPTION
### Motivation
- Mobile portrait behavior put the import button and hint inside the scrollable list, making them disappear while scrolling; they should remain visible like in the desktop left panel. 
- Mobile landscape behavior constrained left/right panels to a fixed height so content could be clipped instead of letting the page scroll and panels expand.
- The change aims to make portrait use internal scrolling for the question list while keeping control rows pinned, and make landscape use page scrolling with unconstrained panels.

### Description
- Updated `css/editor.css` to add orientation-specific rules for `@media (max-width:720px) and (orientation: portrait)` and `@media (max-width:720px) and (orientation: landscape)`.
- In portrait: made `.left` a column flex container with `display:flex` and `flex-direction:column`, moved scrolling to `.left .list` (`overflow:auto`) and marked `.left .hint` and `.left .row` as non-scrolling (`flex:0 0 auto`) so import/hint stay pinned.
- In portrait: kept `rightPanel` and `.alist` scrollable internally with `overflow:auto` so right-side content still scrolls inside its card.
- In landscape: restored page-level scrolling (`body.editor-body { overflow: auto }`) and removed height constraints by setting `height:auto`, `min-height:auto`, `max-height:none`, and `overflow:visible` on `.wrap`, `.layout`, `.left`, and `.rightPanel`, and made `.list`/`.alist` unconstrained so panels expand to fit content.

### Testing
- Ran `git diff --check` which reported no issues and completed successfully.
- Served the app with `python3 -m http.server 4173` and captured visual validation screenshots using Playwright for mobile portrait and landscape; both screenshots show pinned import/hint in portrait and expanded panels in landscape.
- Confirmed the updated `css/editor.css` block contains the new orientation-specific rules and that the layout behavior in both orientations matches the intended fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699274f578b4832191c77180d99dd351)