### PR TITLE
Fix mobile builder header layout; tune editor mobile card sizing, AddTile colors, and orientation rules

### DIFF
--- a/css/builder.css
+++ b/css/builder.css
@@ -87,6 +87,12 @@ body.builder-body > main.wrap{
   margin-bottom: 12px;
 }
 
+@media (max-width: 900px){
+  .bar{
+    display: block;
+  }
+}
+
 .title{
   font-size: 18px;
   font-weight: 900;

--- a/css/editor.css
+++ b/css/editor.css
@@ -367,6 +367,14 @@ body.editor-body .wrap {
     font-weight: 800
 }
 
+.addTile .txt {
+    color: #fff
+}
+
+.addTile .sub {
+    color: rgba(255,255,255,.82)
+}
+
 .qcard:not(.addTile).good {
     border-color: rgba(120,255,120,.45);
     background: rgba(120,255,120,.1)
@@ -470,7 +478,8 @@ body.editor-body .wrap {
 
     .qcard {
         padding: 10px;
-        border-radius: 16px
+        border-radius: 16px;
+        min-height: 72px
     }
 
     .qord {
@@ -496,7 +505,8 @@ body.editor-body .wrap {
 
     .addTile {
         padding: 10px;
-        border-radius: 16px
+        border-radius: 16px;
+        min-height: 72px
     }
 
     .addTile .plus {
@@ -602,18 +612,57 @@ body.editor-body .rightPanel {
     }
 }
 
-@media (max-width:720px) {
-    body.editor-body .wrap {
-        height: auto;
-        overflow: visible;
+@media (max-width:720px) and (orientation: portrait) {
+    body.editor-body {
+        overflow: hidden;
     }
 
+    body.editor-body .wrap {
+        height: calc(100dvh - 72px);
+        overflow: hidden;
+    }
+
+    body.editor-body .left {
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+    }
+
+    body.editor-body .left .list {
+        flex: 1 1 auto;
+        min-height: 0;
+        max-height: none;
+        overflow: auto;
+    }
+
+    body.editor-body .left .hint,
+    body.editor-body .left .row {
+        flex: 0 0 auto;
+    }
+
+    body.editor-body .rightPanel,
+    body.editor-body .alist {
+        overflow: auto;
+    }
+}
+
+@media (max-width:720px) and (orientation: landscape) {
     body.editor-body {
         overflow: auto;
     }
 
+    body.editor-body .wrap,
+    body.editor-body .layout {
+        height: auto;
+        min-height: auto;
+        max-height: none;
+        overflow: visible;
+    }
+
     body.editor-body .left,
     body.editor-body .rightPanel {
+        height: auto;
+        min-height: unset;
         max-height: none;
         overflow: visible;
     }
@@ -621,18 +670,6 @@ body.editor-body .rightPanel {
     body.editor-body .list,
     body.editor-body .alist {
         max-height: none;
-        overflow: visible;
-    }
-}
-
-@media (max-width:720px) and (orientation: portrait) {
-    body.editor-body .wrap {
-        height: auto;
-        overflow: visible;
-    }
-
-    body.editor-body .left,
-    body.editor-body .rightPanel {
         overflow: visible;
     }
 }


### PR DESCRIPTION
### Motivation
- Mobile layouts were collapsing or inheriting undesirable flex/min-height constraints causing cramped/illegible UI on small screens.
- The builder header `.bar` should stop using a horizontal `flex` layout on small viewports to avoid layout breakage.
- `AddTile` text needed forced light coloring for readability on dark backgrounds and portrait/landscape orientation handling needed clearer rules.

### Description
- Added a mobile override in `css/builder.css` to set `.bar { display: block; }` under `@media (max-width: 900px)` so the header no longer relies on horizontal `flex` on small screens.  
- In `css/editor.css` forced light text for `AddTile` via `.addTile .txt { color: #fff }` and tuned subtitle color via `.addTile .sub { color: rgba(255,255,255,.82) }`.  
- Prevented mobile portrait cards from collapsing by adding `min-height: 72px` to `.qcard` and `.addTile` inside the portrait media block.  
- Reworked mobile orientation rules in `css/editor.css`: portrait now constrains the editor viewport with `body.editor-body { overflow: hidden }`, `body.editor-body .wrap { height: calc(100dvh - 72px); overflow: hidden }` and makes the left column list scroll internally (`.left .list { overflow: auto; flex: 1 1 auto }`); landscape restores page scrolling (`body.editor-body { overflow: auto }`) and unsets earlier `min-height`/max-height constraints so panels can expand (`min-height: unset`, `overflow: visible`).

### Testing
- Ran `git diff --check` and it completed without issues. (success)
- Served the app locally and captured a Playwright screenshot for the builder mobile viewport (`builder.html`) to validate the `.bar` change; screenshot artifact was produced. (success)
- Committed the updated `css/builder.css` and `css/editor.css` after validation. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699274f578b4832191c77180d99dd351)