### PR TITLE
Swap mobile back button behavior and use content-based heights in mobile editor

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -375,6 +375,23 @@ body.editor-body .wrap {
     color: rgba(255,255,255,.82)
 }
 
+.addTile:disabled,
+.addTile[aria-disabled="true"] {
+    opacity: .85 !important;
+    color: rgba(255,255,255,.92);
+    border-color: rgba(255,255,255,.32);
+}
+
+.addTile:disabled .txt,
+.addTile:disabled .sub,
+.addTile:disabled .plus,
+.addTile[aria-disabled="true"] .txt,
+.addTile[aria-disabled="true"] .sub,
+.addTile[aria-disabled="true"] .plus {
+    color: rgba(255,255,255,.92);
+    opacity: 1;
+}
+
 .qcard:not(.addTile).good {
     border-color: rgba(120,255,120,.45);
     background: rgba(120,255,120,.1)
@@ -572,6 +589,10 @@ body.editor-body .wrap {
     flex-direction: column;
 }
 
+body.editor-body.mobile-editing {
+    overflow: hidden;
+}
+
 body.editor-body .layout {
     min-height: 0;
     flex: 1;
@@ -584,10 +605,6 @@ body.editor-body .rightPanel {
 
 body.editor-body .rightPanel {
     overflow: auto;
-}
-
-#btnMobileBack {
-    display: none;
 }
 
 @media (max-width:1100px) {
@@ -607,42 +624,57 @@ body.editor-body .rightPanel {
         display: none;
     }
 
-    body.editor-body.mobile-editing #btnMobileBack {
-        display: inline-flex !important;
-    }
 }
 
 @media (max-width:720px) and (orientation: portrait) {
-    body.editor-body {
+    body.editor-body:not(.mobile-editing) {
         overflow: hidden;
     }
 
-    body.editor-body .wrap {
+    body.editor-body:not(.mobile-editing) .wrap {
         height: calc(100dvh - 72px);
         overflow: hidden;
     }
 
-    body.editor-body .left {
+    body.editor-body:not(.mobile-editing) .left {
         display: flex;
         flex-direction: column;
         min-height: 0;
     }
 
-    body.editor-body .left .list {
+    body.editor-body:not(.mobile-editing) .left .list {
         flex: 1 1 auto;
         min-height: 0;
         max-height: none;
         overflow: auto;
     }
 
-    body.editor-body .left .hint,
-    body.editor-body .left .row {
+    body.editor-body:not(.mobile-editing) .left .hint,
+    body.editor-body:not(.mobile-editing) .left .row {
         flex: 0 0 auto;
     }
 
-    body.editor-body .rightPanel,
-    body.editor-body .alist {
-        overflow: auto;
+    body.editor-body.mobile-editing {
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+
+    body.editor-body.mobile-editing .wrap,
+    body.editor-body.mobile-editing .layout {
+        height: auto;
+        min-height: auto;
+        max-height: none;
+        overflow: visible;
+    }
+
+    body.editor-body.mobile-editing .rightPanel {
+        min-height: auto;
+        overflow: visible;
+    }
+
+    body.editor-body.mobile-editing .alist {
+        max-height: none;
+        overflow: visible;
     }
 }
 
@@ -655,10 +687,6 @@ body.editor-body .rightPanel {
         overflow-y: auto;
     }
 
-    body.editor-body {
-        min-height: 100dvh;
-    }
-
     body.editor-body .wrap,
     body.editor-body .layout {
         height: auto;
@@ -669,7 +697,6 @@ body.editor-body .rightPanel {
 
     body.editor-body .left,
     body.editor-body .rightPanel {
-        height: auto;
         min-height: auto;
         max-height: none;
         overflow: visible;
@@ -681,3 +708,4 @@ body.editor-body .rightPanel {
         overflow: visible;
     }
 }
+

--- a/editor.html
+++ b/editor.html
@@ -39,7 +39,6 @@
       </div>
 
       <div class="namebar">
-        <button class="btn" id="btnMobileBack" type="button" style="display:none;" data-i18n="editor.backToQuestions">← Wstecz</button>
         <input id="gameName" class="inp" placeholder="Nazwa gry" data-i18n-placeholder="editor.gameNamePlaceholder"/>
       </div>
     </div>

--- a/js/pages/editor.js
+++ b/js/pages/editor.js
@@ -498,7 +498,12 @@ async function boot() {
     location.href = "index.html";
   });
 
-  $("btnBack")?.addEventListener("click", () => {
+  const btnBack = $("btnBack");
+  btnBack?.addEventListener("click", () => {
+    if (document.body.classList.contains("mobile-editing")) {
+      leaveQuestionEditor();
+      return;
+    }
     location.href = "builder.html";
   });
 
@@ -600,7 +605,6 @@ async function boot() {
   const qText = $("qText");
   const aList = $("aList");
   const rightPanel = document.querySelector(".rightPanel");
-  const btnMobileBack = $("btnMobileBack");
 
   const MOBILE_LAYOUT_BREAKPOINT = 1100;
   const isMobileLayout = () => window.matchMedia(`(max-width:${MOBILE_LAYOUT_BREAKPOINT}px)`).matches;
@@ -608,6 +612,9 @@ async function boot() {
   function syncMobileEditingState() {
     const on = isMobileLayout() && !!activeQId;
     document.body.classList.toggle("mobile-editing", on);
+    if (btnBack) {
+      btnBack.textContent = on ? `← ${t("editor.backToQuestions")}` : `← ${t("editor.backToGames")}`;
+    }
   }
 
   function setHasQ(on) {
@@ -615,12 +622,14 @@ async function boot() {
     syncMobileEditingState();
   }
 
-  btnMobileBack?.addEventListener("click", () => {
+  function leaveQuestionEditor() {
+    if (!activeQId) return;
     activeQId = null;
     answers = [];
     renderQuestions();
     renderEditor();
-  });
+  }
+
 
   // KLUCZ: liczymy count + (prepared) sumę punktów -> do kafelków i kolorów
   async function refreshCounts() {
@@ -933,7 +942,7 @@ async function boot() {
     addA.className = "arow addTile";
     addA.disabled = !canAdd;
     addA.style.cursor = canAdd ? "pointer" : "not-allowed";
-    addA.style.opacity = canAdd ? "1" : ".55";
+    addA.setAttribute("aria-disabled", canAdd ? "false" : "true");
     addA.innerHTML = `
       <div style="font-weight:1000;">
         ${canAdd ? MSG.addAnswerLabel() : MSG.answerLimitReached()}


### PR DESCRIPTION
### Motivation
- Fix review feedback so the mobile "← Wstecz" does not sit next to "← Moje gry" but replaces it, and mobile card heights grow to fit content instead of being forced to viewport height.
- Improve accessibility/contrast for disabled add-tile state so its appearance is more consistent when disabled.

### Description
- Removed the separate `#btnMobileBack` element from `editor.html` and reused `#btnBack` instead so the back button swaps label and action rather than appearing side-by-side (file: `editor.html`).
- Updated `js/pages/editor.js` to reuse `btnBack`, make its click handler call `leaveQuestionEditor()` when in `mobile-editing`, and update `syncMobileEditingState()` to switch the button label between games/questions (file: `js/pages/editor.js`).
- Reworked mobile CSS rules in `css/editor.css` to remove forced `100dvh` / `calc(100dvh - 72px)` min-heights for portrait/landscape mobile editing, replacing them with `min-height: auto` and visible overflow so panels/cards expand to the content height (file: `css/editor.css`).
- Added visual/ARIA adjustments for the add-tile button: set `aria-disabled` on the JS side and added CSS rules for `.addTile:disabled` / `[aria-disabled="true"]` to improve disabled-state appearance (files: `js/pages/editor.js`, `css/editor.css`).

### Testing
- Ran `node --check js/pages/editor.js` to validate JS syntax and it passed.
- Served the app with `python -m http.server 4173` and validated the editor UI in a headless browser session using Playwright, capturing a screenshot to confirm the back-button label swap and layout behavior (screenshot captured successfully).
- Committed the changes and verified the modified files load without runtime syntax errors during the local validation steps above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69930ad94c808321b0c0a6abefa4843c)