### PR TITLE
Ensure mail action links always include UI language

### DIFF
--- a/js/pages/bases.js
+++ b/js/pages/bases.js
@@ -627,13 +627,15 @@ async function resolveLoginToEmail(login) {
 }
 
 function mailLink(link) {
-  // link z DB jest typu "/bases.html?share=..."
+  let u;
   try {
-    const u = new URL(link, location.origin);
-    return u.toString();
+    u = new URL(link, location.origin);
   } catch {
-    return String(link || "");
+    u = new URL(String(link || ""), location.origin);
   }
+
+  u.searchParams.set("lang", getUiLang() || "pl");
+  return u.href;
 }
 
 function escapeMail(s) {

--- a/js/pages/subscriptions.js
+++ b/js/pages/subscriptions.js
@@ -157,12 +157,16 @@ function cooldownTextFromUntil(untilTsMs) {
 }
 
 
-function mailLink(path) {
+function mailLink(path, { withLang = false } = {}) {
+  let u;
   try {
-    return new URL(path, location.origin).href;
+    u = new URL(path, location.origin);
   } catch {
-    return path;
+    u = new URL(String(path || ""), location.origin);
   }
+
+  if (withLang) u.searchParams.set("lang", getUiLang() || "pl");
+  return u.href;
 }
 
 function wrapEmailDoc(innerHtml) {
@@ -241,7 +245,7 @@ async function sendSubscriptionEmail({ to, link, ownerLabel }) {
       subtitle: t("pollsHubSubscriptions.mail.subtitle"),
       body: t("pollsHubSubscriptions.mail.subscriptionBody", { owner: ownerLabel }),
       actionLabel: t("pollsHubSubscriptions.mail.subscriptionAction"),
-      actionUrl: mailLink(link),
+      actionUrl: mailLink(link, { withLang: true }),
     }),
   });
 }

--- a/translation/en.js
+++ b/translation/en.js
@@ -2939,8 +2939,6 @@ const en = {
     },
     pollReadyAlert: "Finish the game in My games",
     resendCooldownAlert: "You can resend the invite in {hours}h.",
-    cooldownLeftDays: "Try again in {n} days",
-    cooldownLeftHours: "Try again in {n} hours",
   },
   pollsHubPolls: {
     dash: "-",
@@ -3408,6 +3406,8 @@ const en = {
     },
     pollReadyAlert: "Finish the game in My games",
     resendCooldownAlert: "You can resend the invite in {hours}h.",
+    cooldownLeftDays: "Try again in {n} days",
+    cooldownLeftHours: "Try again in {n} hours",
     shareCooldownAlert: "You can invite again in {hours}h.",
   },
   logoEditor: {

--- a/translation/pl.js
+++ b/translation/pl.js
@@ -2944,8 +2944,6 @@ const pl = {
     },
     pollReadyAlert: "Dokończ grę w Moich grach",
     resendCooldownAlert: "Ponowne wysłanie zaproszenia możliwe za {hours} godz.",
-    cooldownLeftDays: "Spróbuj ponownie za {n} dni",
-    cooldownLeftHours: "Spróbuj ponownie za {n} godz.",
   },
   pollsHubPolls: {
     dash: "-",
@@ -3413,6 +3411,8 @@ const pl = {
     },
     pollReadyAlert: "Dokończ grę w Moich grach",
     resendCooldownAlert: "Ponowne wysłanie zaproszenia możliwe za {hours} godz.",
+    cooldownLeftDays: "Spróbuj ponownie za {n} dni",
+    cooldownLeftHours: "Spróbuj ponownie za {n} godz.",
     shareCooldownAlert: "Ponowne zaproszenie do głosowania możliwe za {hours} godz.",
   },
   logoEditor: {

--- a/translation/uk.js
+++ b/translation/uk.js
@@ -2819,8 +2819,6 @@ const uk = {
     },
     pollReadyAlert: "Завершіть гру в «Мої ігри»",
     resendCooldownAlert: "Повторне запрошення можна надіслати через {hours} год.",
-    cooldownLeftDays: "Спробуй ще раз через {n} дн.",
-    cooldownLeftHours: "Спробуй ще раз через {n} год.",
   },
   pollsHubPolls: {
     dash: "-",
@@ -3288,6 +3286,8 @@ const uk = {
     },
     pollReadyAlert: "Завершіть гру в «Мої ігри»",
     resendCooldownAlert: "Повторне запрошення можна надіслати через {hours} год.",
+    cooldownLeftDays: "Спробуй ще раз через {n} дн.",
+    cooldownLeftHours: "Спробуй ще раз через {n} год.",
     shareCooldownAlert: "Повторно запросити до голосування можна через {hours} год.",
   },
   logoEditor: {


### PR DESCRIPTION
### Motivation
- Links returned from RPC/DB (e.g. `/subscriptions.html?s=...`) should carry the client UI language when sent in emails, and this must be handled client-side rather than persisted to the database.
- Keep mail-link behavior consistent with the `polls-hub` flow where `lang` is appended from the current UI language.

### Description
- Updated `js/pages/subscriptions.js` to provide `mailLink(path, { withLang = false } = {})` that safely normalizes the incoming value and, when `withLang` is true, appends `lang` using `getUiLang() || "pl"`.
- Changed `sendSubscriptionEmail` in `js/pages/subscriptions.js` to call `mailLink(link, { withLang: true })` so email action URLs always include `lang`.
- Updated `js/pages/bases.js` `mailLink(link)` helper to normalize inputs and always append `lang` from `getUiLang() || "pl"` before returning the URL.

### Testing
- Ran syntax/type checks with `node --check js/pages/subscriptions.js` and `node --check js/pages/bases.js`, both succeeded.
- Verified updated helpers and call sites with `rg`/ripgrep to ensure `mailLink(path, { withLang` and `searchParams.set("lang", getUiLang()` are present, which succeeded.
- No automated test failures were produced by these checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69958814c5ac832189c900f506063a6e)