### PR TITLE
Harden send-email email-change extraction and add adaptive CAPTCHA/login retry

### DIFF
--- a/js/core/auth.js
+++ b/js/core/auth.js
@@ -285,14 +285,17 @@ export async function discardCurrentGuestAccount() {
   clearGuestLocalMarker();
 }
 
-export async function signIn(login, password) {
+export async function signIn(login, password, captchaToken = null) {
   const email = await loginToEmail(login);
   if (!email) {
     if (String(login || "").includes("@")) throw new Error(t("auth.unknownEmail"));
     throw new Error(t("auth.unknownUsername"));
   }
 
-  const { data, error } = await sb().auth.signInWithPassword({ email, password });
+  const payload = { email, password };
+  if (captchaToken) payload.options = { captchaToken };
+
+  const { data, error } = await sb().auth.signInWithPassword(payload);
   if (error) throw new Error(niceAuthError(error));
 
   const user = data.user;


### PR DESCRIPTION
### Motivation
- `send-email` webhook sometimes received missing/invalid `email_data.redirect_to` or `new_email`, causing the function to log `undefined` and skip sending the new-email confirmation.  
- Login flow should avoid forcing CAPTCHA for normal users but still protect against brute-force attempts by showing CAPTCHA after repeated failures and handling backend CAPTCHA errors gracefully.  
- Improve reliability when building action links and extracting the target new address across multiple Supabase webhook variants and rollout differences.

### Description
- In `supabase/functions/send-email/index.ts` added `action_link`, `old_email`, and `new_email` to the `HookPayload` type and replaced the strict `mustGetRedirectUrl` with `getRedirectUrl` (returns `null` on missing/invalid `redirect_to`).  
- Introduced `getBaseOrigin` fallback chain for link generation (`redirect_to` → `action_link` → `SITE_URL`) and updated logging to remove fragile casts; expanded `extractTargetEmail` to derive the target email from `redirect_to` params, `action_link` params, `user.email_new`, `email_data.new_email`, and `user_metadata.familiada_email_change_pending`.  
- In `js/core/auth.js` changed `signIn` to accept an optional `captchaToken` and to only set `payload.options = { captchaToken }` when present, preserving previous behavior otherwise via `sb().auth.signInWithPassword(payload)`.  
- In `js/pages/login.js` added adaptive CAPTCHA policy with per-identity failure counters and `LOGIN_CAPTCHA_FAIL_THRESHOLD = 3`, language-aware and script-reuse improvements for `loadCaptchaApi`, an `askCaptchaToken()` flow that supports retrying login once when the backend returns a CAPTCHA-related error, and cleanup/robustness around widget onload/error handling and language selection.

### Testing
- Attempted to run `deno check supabase/functions/send-email/index.ts` but Deno is not available in this environment so type-check was not executed.  
- Reviewed changes with `git diff` and inspected the committed patch via `git show --stat --oneline HEAD`.  
- Verified file edits by grepping relevant tokens (`redirect_to`, `new_email`, `action_link`, `captcha`) to ensure new code paths are present and committed with a descriptive message (`Harden send-email email-change target extraction`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69986851a1f08321b4fb51ff96e8f4f8)