### PR TITLE
Set password during guest upgrade and fix Supabase email_change token mapping

### DIFF
--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -339,21 +339,26 @@ const tokenHash = payload.email_data.token_hash || "";
 
       const subject = subjectFor("email_change", lang);
 
-      // linki (fallbacki na wypadek zamiany nazw przez Supabase)
+      // mapping zgodny z Supabase:
+      // - token_hash      => current email
+      // - token_hash_new  => new email (lub token_hash jeśli secure email change OFF)
+      const thCurrent = tokenHash;
+      const thNew = tokenHashNew || tokenHash;
+
       const linkCurrent =
-        `${baseOrigin}/confirm.html?token_hash=${encodeURIComponent(tokenHashNew || tokenHash)}&type=email_change&lang=${lang}`;
+        `${baseOrigin}/confirm.html?token_hash=${encodeURIComponent(thCurrent)}&type=email_change&lang=${lang}`;
       const linkTarget =
-        `${baseOrigin}/confirm.html?token_hash=${encodeURIComponent(tokenHash || tokenHashNew)}&type=email_change&lang=${lang}`;
+        `${baseOrigin}/confirm.html?token_hash=${encodeURIComponent(thNew)}&type=email_change&lang=${lang}`;
 
       // ✅ CURRENT mail zawsze na payload.user.email
-      if (currentEmail) {
+      if (currentEmail && thCurrent) {
         await sendEmail(currentEmail, subject, renderEmailChange(lang, linkCurrent));
         console.log("[send-email] sent:email_change_current", { to: scrubEmail(currentEmail) });
       }
 
       // ✅ NEW mail tylko jeśli znamy adres z redirect_to?to=
       // I to działa zarówno dla email_change_new, jak i dla “pojedynczego” email_change
-      if (targetEmail && targetEmailNormalized !== currentEmailNormalized) {
+      if (targetEmail && thNew && targetEmailNormalized !== currentEmailNormalized) {
         await sendEmail(targetEmail, subject, renderEmailChange(lang, linkTarget));
         console.log("[send-email] sent:email_change_new", { to: scrubEmail(targetEmail) });
       }


### PR DESCRIPTION
### Motivation
- Restore intuitive UX by setting the account `password` immediately when converting a guest to a registered user. 
- Ensure email-change notification links follow Supabase's token mapping so both current and new email confirmations behave deterministically.

### Description
- Updated `js/core/auth.js` `convertGuestToRegistered` to include `password` in the `updateUser` payload, preserve `emailRedirectTo` as the second argument, append `to=<email>` to the redirect URL, and set `familiada_email_change_pending` in user metadata. 
- Adjusted guest conversion flow so the same anonymous user receives `email + password`, the confirmation is triggered via `email_change`, and existing local guest marker is cleared only after `email_confirmed_at` is true. 
- Modified `supabase/functions/send-email/index.ts` to map tokens per Supabase expectations (`token_hash` => current email, `token_hash_new` => new email with fallback to `token_hash`), introduced `thCurrent`/`thNew` variables, and added guards to only send mails when the appropriate token exists and the target differs from current email.

### Testing
- Ran `node --check js/core/auth.js` and it completed successfully. 
- Attempted a TypeScript/Deno check for `supabase/functions/send-email/index.ts` but `deno` is not available in the environment so that automated check could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699873676aa0832194b2d6205f65597d)