### PR TITLE
Avoid false CAPTCHA prompts on auth 5xx and add email fallbacks for email_change hooks

### DIFF
--- a/js/pages/login.js
+++ b/js/pages/login.js
@@ -78,6 +78,8 @@ function isCaptchaChallengeError(error) {
   const raw = String(
     error?.message || error?.error_description || error?.description || error || ""
   ).toLowerCase();
+  const status = Number(error?.status || error?.statusCode || 0) || 0;
+  if (status >= 500 || raw.includes("unexpected_failure") || raw.includes("internal")) return false;
   return raw.includes("captcha") && (
     raw.includes("required") || raw.includes("invalid") || raw.includes("failed")
   );


### PR DESCRIPTION
### Motivation
- Prevent the UI from showing a misleading `CAPTCHA required` prompt when the Auth API returns backend errors (5xx or internal failures). 
- Ensure `email_change` webhook handling still delivers confirmation links when webhook payloads omit email fields by falling back to the Auth admin API and user metadata.

### Description
- Tighten CAPTCHA detection in `niceAuthError` by reading `e.status`/`e.statusCode` and returning a generic login failure when `status >= 500` or message contains `unexpected_failure`/`internal`, instead of `index.captchaRequired` (`js/core/auth.js`).
- Align the login page helper by updating `isCaptchaChallengeError` to ignore captcha-like messages from server-side 5xx/internal failures so the CAPTCHA prompt/retry flow is not triggered (`js/pages/login.js`).
- Extend the webhook payload typing to allow an optional `user.id` and add `loadUserEmailFallbacks(userId)` which uses the service-role client (`sbAdmin.auth.admin.getUserById`) to fetch `email`, pending `email_change` and `familiada_email_change_pending` metadata (`supabase/functions/send-email/index.ts`).
- Use the fetched fallbacks when handling `email_change*` hooks to resolve `currentEmail` and `targetEmail` via `firstEmail(...)` so both current and new confirmation emails are sent where possible, while preserving existing token/link mapping and send logic (`supabase/functions/send-email/index.ts`).

### Testing
- Ran `node --check js/core/auth.js` which completed successfully. 
- Ran `node --check js/pages/login.js` which completed successfully. 
- `supabase/functions/send-email/index.ts` changes were not validated with `deno` tooling in this environment because `deno` was not available, so Deno-based format/type checks were skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69987be3437483219e7ba2400712da3d)