### PR TITLE
Show CAPTCHA only after configured failed attempts; preserve Supabase auth error metadata

### DIFF
--- a/js/core/auth.js
+++ b/js/core/auth.js
@@ -310,7 +310,15 @@ export async function signIn(login, password, captchaToken = null) {
   if (captchaToken) payload.options = { captchaToken };
 
   const { data, error } = await sb().auth.signInWithPassword(payload);
-  if (error) throw new Error(niceAuthError(error));
+  if (error) {
+    const wrapped = new Error(niceAuthError(error));
+    wrapped.status = Number(error?.status || error?.statusCode || 0) || 0;
+    wrapped.errorCode = String(error?.code || error?.error_code || "").trim().toLowerCase();
+    wrapped.rawMessage = String(
+      error?.message || error?.error_description || error?.description || ""
+    ).trim();
+    throw wrapped;
+  }
 
   const user = data.user;
   if (!user) throw new Error(t("auth.loginFailed"));


### PR DESCRIPTION
### Motivation
- Normal logins must not be forced into CAPTCHA based on backend error text and should only show CAPTCHA after the local failure threshold (`LOGIN_CAPTCHA_FAIL_THRESHOLD`, i.e. 3 failures). 
- Preserve original Supabase/GoTrue error metadata so decision logic can access backend context without leaking raw messages to the user-facing text.

### Description
- In `js/pages/login.js`, removed backend-driven CAPTCHA escalation by deleting `isCaptchaChallengeError`, changed `getCaptchaPromptForLogin` to consult only `getLoginCaptchaPolicy`, and simplified the login submit flow to call `getCaptchaPromptForLogin` once and then `signIn` without an automatic retry-on-error path. 
- In `js/core/auth.js`, wrapped errors returned from `sb().auth.signInWithPassword` in a new `Error` that keeps the localized `niceAuthError(error)` message while attaching `status`, `errorCode`, and `rawMessage` properties for programmatic inspection. 
- No user-facing UI text changes were made.

### Testing
- Ran `node --check js/pages/login.js` and `node --check js/core/auth.js`, both checks succeeded. 
- Ran `git diff --check` which completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69987e8da0d08321b1cd8d1a14614853)