### PR TITLE
fix: sfx advanced — scalenie kart, przycisk ▶ i tłumaczenie confirmModal

### DIFF
--- a/control-new.html
+++ b/control-new.html
@@ -408,40 +408,39 @@
                   </div>
                 </div>
 
+                  <!-- Zaawansowane ustawienia dźwięku — w tej samej karcie -->
+                  <div class="sfx-advanced-section">
+                    <button class="sfx-advanced-toggle" id="btnSfxAdvanced" type="button">
+                      <span class="sfx-toggle-arrow">▶</span>
+                      <span data-i18n="control.sfxAdvanced">Zaawansowane</span>
+                    </button>
+
+                    <div class="sfx-advanced-body hidden" id="sfxAdvancedBody">
+                      <div class="sfx-table" id="sfxTable">
+                        <!-- wiersze generowane dynamicznie przez JS -->
+                      </div>
+
+                      <div class="sfx-advanced-foot">
+                        <button class="btn" id="btnSfxReset" type="button"
+                          data-i18n="control.sfxResetAll">Przywróć domyślne</button>
+
+                        <label class="sfx-save-check hidden" id="sfxSaveWrap">
+                          <input type="checkbox" id="chkSfxSave"/>
+                          <span data-i18n="control.sfxSaveCloud">Zapisz w chmurze</span>
+                        </label>
+                        <button class="btn gold hidden" id="btnSfxSave" type="button"
+                          data-i18n="control.sfxSaveBtn">Zapisz</button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
                 <div class="stepFoot step-foot-spaced">
                   <div class="stepFootButtons">
                     <button class="btn" id="btnAudioBack" type="button" data-i18n="common.back">Wstecz</button>
                     <button class="btn gold" id="btnDevicesFinish" type="button" disabled data-i18n="control.devicesFinish">Gotowe — przejdź dalej</button>
                   </div>
                   <div class="msg msg-pill" id="msgAudio"></div>
-                </div>
-              </div>
-
-              <!-- Zaawansowane ustawienia dźwięku -->
-              <div class="card sfx-advanced-card">
-                <div class="cardBody">
-                  <button class="sfx-advanced-toggle" id="btnSfxAdvanced" type="button">
-                    <span class="sfx-toggle-arrow">▶</span>
-                    <span data-i18n="control.sfxAdvanced">Zaawansowane</span>
-                  </button>
-
-                  <div class="sfx-advanced-body hidden" id="sfxAdvancedBody">
-                    <div class="sfx-table" id="sfxTable">
-                      <!-- wiersze generowane dynamicznie przez JS -->
-                    </div>
-
-                    <div class="sfx-advanced-foot">
-                      <button class="btn" id="btnSfxReset" type="button"
-                        data-i18n="control.sfxResetAll">Przywróć domyślne</button>
-
-                      <label class="sfx-save-check hidden" id="sfxSaveWrap">
-                        <input type="checkbox" id="chkSfxSave"/>
-                        <span data-i18n="control.sfxSaveCloud">Zapisz w chmurze</span>
-                      </label>
-                      <button class="btn gold hidden" id="btnSfxSave" type="button"
-                        data-i18n="control.sfxSaveBtn">Zapisz</button>
-                    </div>
-                  </div>
                 </div>
               </div>
             </div>

--- a/control-new/control.css
+++ b/control-new/control.css
@@ -2272,8 +2272,10 @@
 
 /* ===== SFX ADVANCED ===== */
 
-.sfx-advanced-card {
-  margin-top: 12px;
+.sfx-advanced-section {
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(255,255,255,.1);
 }
 
 .sfx-advanced-toggle {

--- a/control-new/js/app.js
+++ b/control-new/js/app.js
@@ -1271,7 +1271,7 @@ async function sendZeroStatesToDevices() {
             <div class="ui-select-menu" role="listbox">${optionsHtml}</div>
           </div>
         </div>
-        <button class="sfx-preview-btn" type="button" title="Podgląd" data-sfx-preview="${key}">🔊</button>
+        <button class="sfx-preview-btn" type="button" title="Odtwórz" data-sfx-preview="${key}">▶</button>
         <div class="sfx-vol-wrap">
           <input type="range" class="sfx-vol" min="0" max="100" value="${volPct}" data-sfx-vol="${key}"/>
           <span class="sfx-vol-label" id="sfxVolLabel_${key}">${volPct}%</span>
@@ -1453,9 +1453,9 @@ async function sendZeroStatesToDevices() {
   document.getElementById("btnSfxReset")?.addEventListener("click", async () => {
     const ok = await confirmModal({
       title: t("control.sfxResetAll"),
-      text: t("common.confirmDefault") || "Przywrócić domyślne ustawienia dźwięku?",
+      text: t("control.sfxResetConfirm"), // klucz zdefiniowany w pl/en/uk
       okText: t("control.sfxResetAll"),
-      cancelText: t("common.cancel") || "Anuluj",
+      cancelText: t("common.cancel"),
     });
     if (!ok) return;
 

--- a/translation/en.js
+++ b/translation/en.js
@@ -4983,6 +4983,7 @@ const en = {
     sfxSaveCloud: "Save to cloud",
     sfxSaveBtn: "Save",
     sfxResetAll: "Restore defaults",
+    sfxResetConfirm: "Restore default sound settings? All custom files and volumes will be removed.",
     sfxTooLongTitle: "File too long",
     sfxTooLong: "Maximum length is {limit}s",
     sfxDesc: {

--- a/translation/pl.js
+++ b/translation/pl.js
@@ -4362,6 +4362,7 @@ const pl = {
     sfxSaveCloud: "Zapisz w chmurze",
     sfxSaveBtn: "Zapisz",
     sfxResetAll: "Przywróć domyślne",
+    sfxResetConfirm: "Przywrócić domyślne ustawienia dźwięku? Wszystkie własne pliki i głośności zostaną usunięte.",
     sfxTooLongTitle: "Plik za długi",
     sfxTooLong: "Maksymalna długość to {limit}s",
     sfxDesc: {

--- a/translation/uk.js
+++ b/translation/uk.js
@@ -4971,6 +4971,7 @@ const uk = {
     sfxSaveCloud: "Зберегти в хмарі",
     sfxSaveBtn: "Зберегти",
     sfxResetAll: "Відновити типові",
+    sfxResetConfirm: "Відновити типові налаштування звуку? Усі власні файли та гучності буде видалено.",
     sfxTooLongTitle: "Файл занадто довгий",
     sfxTooLong: "Максимальна тривалість — {limit}с",
     sfxDesc: {


### PR DESCRIPTION
- Zaawansowane w tej samej karcie co odblokowanie dźwięku
- Przycisk ▶ jako osobna kolumna (odtwarza aktywny dźwięk niezależnie od źródła)
- Dodano klucz `sfxResetConfirm` w pl/en/uk (brakujące tłumaczenie confirmModal)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9fT5Zipto4yThm1UQFobs)_