### PR TITLE
docs: plan per-game settings

### DIFF
--- a/builder-new.html
+++ b/builder-new.html
@@ -44,6 +44,11 @@
         <span class="badge" id="basesBadge" aria-hidden="true"></span>
       </button>
 
+      <button class="btn" id="btnConnectDevice" data-nav-hidden="true" style="display:none;">
+        <span data-i18n="builder.nav.connectDevice">Podłącz urządzenie 📱</span>
+        <span class="badge" id="connectDeviceBadge" aria-hidden="true"></span>
+      </button>
+
       <button class="btn" id="btnPollsHub">
         <span data-i18n="builder.nav.pollsHubPolls">Ankiety 📊</span>
         <span class="badge" id="pollsHubBadge" aria-hidden="true"></span>
@@ -52,11 +57,6 @@
       <button class="btn" id="btnSubscriptionsHub">
         <span data-i18n="builder.nav.pollsHubSubs">Subskrypcje 📧</span>
         <span class="badge" id="subscriptionsHubBadge" aria-hidden="true"></span>
-      </button>
-
-      <button class="btn" id="btnConnectDevice" data-nav-hidden="true" style="display:none;">
-        <span data-i18n="builder.nav.connectDevice">Podłącz urządzenie 📱</span>
-        <span class="badge" id="connectDeviceBadge" aria-hidden="true"></span>
       </button>
 
       <div class="nav-more" id="navMore" style="display:none;">

--- a/builder-new.html
+++ b/builder-new.html
@@ -20,7 +20,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
   <script src="js/core/security-warning.js?v=v2026-06-03T21150" defer></script>
-  <script type="module" src="js/pages/builder.js?v=v2026-06-03T21150" defer></script>
+  <script type="module" src="js/pages/builder-new.js?v=v2026-06-03T21150" defer></script>
   <script type="module" src="js/core/topbar-controller.js?v=v2026-06-03T21150" defer></script>
 </head>
 

--- a/builder-new.html
+++ b/builder-new.html
@@ -1,0 +1,334 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate">
+  <meta name="app-version" content="v2026-06-03T21150"/>
+
+  <meta charset="UTF-8"/>
+  <meta name="robots" content="noindex, nofollow"/>
+  <meta name="mobile-web-app-capable" content="yes"/>
+  <meta name="apple-mobile-web-app-capable" content="yes"/>
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
+  <title data-i18n="builder.title">Familiada — moje gry</title>
+
+  <link rel="icon" href="favicon.ico?v=v2026-06-03T21150"/>
+  <link rel="manifest" href="/manifest.json?v=v2026-06-03T21150"/>
+  <meta name="theme-color" content="#050914"/>
+  <link rel="stylesheet" href="css/base.css?v=v2026-06-03T21150"/>
+  <link rel="stylesheet" href="css/builder.css?v=v2026-06-03T21150"/>
+
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
+  <script src="js/core/security-warning.js?v=v2026-06-03T21150" defer></script>
+  <script type="module" src="js/pages/builder.js?v=v2026-06-03T21150" defer></script>
+  <script type="module" src="js/core/topbar-controller.js?v=v2026-06-03T21150" defer></script>
+</head>
+
+<body class="builder-body">
+  <header class="topbar topbar-layout-4 topbar-mobile-keep-brand">
+    <div class="topbar-section topbar-section-1">
+      <div class="brand">FAMILIADA</div>
+    </div>
+    <div class="topbar-section topbar-section-2">
+      <button class="btn" id="btnMarketplace">
+        <span data-i18n="builder.nav.marketplace">Gry Społeczności 🎮</span>
+        <span class="badge" id="marketplaceBadge" aria-hidden="true"></span>
+      </button>
+
+      <button class="btn" id="btnLogoEditor">
+        <span data-i18n="builder.nav.logo">Logo 🖥️</span>
+      </button>
+
+      <button class="btn" id="btnBases">
+        <span data-i18n="builder.nav.bases">Bazy pytań 🗃️</span>
+        <span class="badge" id="basesBadge" aria-hidden="true"></span>
+      </button>
+
+      <button class="btn" id="btnPollsHub">
+        <span data-i18n="builder.nav.pollsHubPolls">Ankiety 📊</span>
+        <span class="badge" id="pollsHubBadge" aria-hidden="true"></span>
+      </button>
+
+      <button class="btn" id="btnSubscriptionsHub">
+        <span data-i18n="builder.nav.pollsHubSubs">Subskrypcje 📧</span>
+        <span class="badge" id="subscriptionsHubBadge" aria-hidden="true"></span>
+      </button>
+
+      <button class="btn" id="btnConnectDevice" data-nav-hidden="true" style="display:none;">
+        <span data-i18n="builder.nav.connectDevice">Podłącz urządzenie 📱</span>
+        <span class="badge" id="connectDeviceBadge" aria-hidden="true"></span>
+      </button>
+
+      <div class="nav-more" id="navMore" style="display:none;">
+        <button class="btn" id="btnMore" type="button">Więcej ▾<span class="badge" id="moreBadge" aria-hidden="true"></span></button>
+        <div class="nav-more-dropdown" id="navMoreDropdown" hidden></div>
+      </div>
+    </div>
+    <div class="topbar-section topbar-section-3">
+      <button class="btn icon-btn" id="btnInstall" type="button" style="display:none;" title="Zainstaluj aplikację"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></button>
+      <button class="btn icon-btn" id="btnManual" type="button">ℹ️</button>
+    </div>
+    <div class="topbar-section topbar-section-4">
+      <div class="who" id="whoStatic">—</div>
+      <button class="btn" id="btnLogout" type="button" data-i18n="common.authEntry">Zaloguj / Załóż konto</button>
+    </div>
+  </header>
+
+  <main class="wrap">
+    <div class="bar">
+      <div>
+        <div class="title" data-i18n="builder.header.title">Twoje gry</div>
+        <div class="hint" id="hint" data-i18n="builder.header.hint">Naciśnij kafelek, żeby go zaznaczyć. Podwójne naciśnięcie zmienia nazwę.</div>
+      </div>
+
+      <div class="actions">
+        <!-- góra: tylko te trzy przyciski -->
+        <button class="btn sm" id="btnPreview" type="button" disabled>
+          <span class="only-desktop" data-i18n="builder.actions.preview">Podgląd</span>
+          <span class="only-mobile" data-i18n="builder.actions.previewMobile">Podgl.</span>
+        </button>
+
+        <button class="btn sm" id="btnEdit" type="button" disabled>
+          <span class="only-desktop" data-i18n="builder.actions.edit">Edytuj</span>
+          <span class="only-mobile" data-i18n="builder.actions.editMobile">Edyt.</span>
+        </button>
+
+        <button class="btn sm gold" id="btnPlay" type="button" disabled>
+          <span class="only-desktop" data-i18n="builder.actions.play">Graj</span>
+          <span class="only-mobile" data-i18n="builder.actions.playMobile">Graj</span>
+        </button>
+
+        <button class="btn sm gold" id="btnPoll" type="button" disabled>
+          <span class="only-desktop" data-i18n="builder.actions.poll">Ankieta</span>
+          <span class="only-mobile" data-i18n="builder.actions.pollMobile">Sond.</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- Karty z wypustką (kształt jak w Twoim pliku) -->
+    <section class="builder-shell">
+      <div class="tabs-card" id="tabs-root">
+        <!-- PASEK ZAKŁADEK -->
+        <div class="tabs-strip">
+          <!-- SLOT 1: typowa ankieta -->
+          <div class="tab-slot slot-pollText">
+            <button class="tab-label" id="tabPollText" type="button">
+              <span class="only-desktop" data-i18n="builder.tabs.pollText">Typowa ankieta</span>
+              <span class="only-mobile" data-i18n="builder.tabs.pollTextMobile">Ankieta</span>
+            </button>
+            <div class="tab-wrapper">
+              <div class="tab-active">
+                <span class="only-desktop" data-i18n="builder.tabs.pollText">Typowa ankieta</span>
+                <span class="only-mobile" data-i18n="builder.tabs.pollTextMobile">Ankieta</span>
+              </div>
+              <div class="tab-corner tab-corner-left"></div>
+              <div class="tab-corner tab-corner-right"></div>
+            </div>
+          </div>
+
+          <!-- SLOT 2: punktacja -->
+          <div class="tab-slot slot-pollPoints">
+            <button class="tab-label" id="tabPollPoints" type="button">
+              <span class="only-desktop" data-i18n="builder.tabs.pollPoints">Punktacja</span>
+              <span class="only-mobile" data-i18n="builder.tabs.pollPointsMobile">Punkty</span>
+            </button>
+            <div class="tab-wrapper">
+              <div class="tab-active">
+                <span class="only-desktop" data-i18n="builder.tabs.pollPoints">Punktacja</span>
+                <span class="only-mobile" data-i18n="builder.tabs.pollPointsMobile">Punkty</span>
+              </div>
+              <div class="tab-corner tab-corner-left"></div>
+              <div class="tab-corner tab-corner-right"></div>
+            </div>
+          </div>
+
+          <!-- SLOT 3: preparowana -->
+          <div class="tab-slot slot-prepared">
+            <button class="tab-label" id="tabPrepared" type="button">
+              <span class="only-desktop" data-i18n="builder.tabs.prepared">Preparowana</span>
+              <span class="only-mobile" data-i18n="builder.tabs.preparedMobile">Gotowa</span>
+            </button>
+            <div class="tab-wrapper">
+              <div class="tab-active">
+                <span class="only-desktop" data-i18n="builder.tabs.prepared">Preparowana</span>
+                <span class="only-mobile" data-i18n="builder.tabs.preparedMobile">Gotowa</span>
+              </div>
+              <div class="tab-corner tab-corner-left"></div>
+              <div class="tab-corner tab-corner-right"></div>
+            </div>
+          </div>
+
+          <!-- SLOT 4: Z marketu -->
+          <div class="tab-slot slot-market">
+            <button class="tab-label" id="tabMarket" type="button">
+              <span class="only-desktop" data-i18n="builder.tabs.market">Gry Społeczności</span>
+              <span class="only-mobile" data-i18n="builder.tabs.marketMobile">Społ.</span>
+            </button>
+            <div class="tab-wrapper">
+              <div class="tab-active">
+                <span class="only-desktop" data-i18n="builder.tabs.market">Gry Społeczności</span>
+                <span class="only-mobile" data-i18n="builder.tabs.marketMobile">Społ.</span>
+              </div>
+              <div class="tab-corner tab-corner-left"></div>
+              <div class="tab-corner tab-corner-right"></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- KARTA POD WYPUSTKĄ -->
+        <div class="card builder-card">
+          <div class="grid" id="grid"></div>
+
+          <div class="builder-bottom">
+            <div class="builder-bottom-left"></div>
+            <div class="builder-bottom-right">
+              <button class="btn sm" id="btnExport" type="button" disabled>
+                <span class="only-desktop" data-i18n="builder.actions.exportFile">Eksportuj do pliku</span>
+                <span class="only-mobile" data-i18n="builder.actions.exportFileMobile">Exp.plk</span>
+              </button>
+              <button class="btn sm" id="btnExportBase" type="button" disabled>
+                <span class="only-desktop" data-i18n="builder.actions.exportBase">Eksportuj do bazy</span>
+                <span class="only-mobile" data-i18n="builder.actions.exportBaseMobile">Exp.bz</span>
+              </button>
+              <button class="btn sm" id="btnImport" type="button">
+                <span class="only-desktop" data-i18n="builder.actions.import">Importuj</span>
+                <span class="only-mobile" data-i18n="builder.actions.importMobile">Imp</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="footer">
+      <div data-i18n="common.footer.left">© 2026 Familiada — system do gry na żywo</div>
+      <button class="btn-contact-footer" type="button" data-contact-modal data-i18n="common.contactBtn">Kontakt</button>
+    </div>
+  </main>
+
+  <!-- Modal: import JSON -->
+  <div class="overlay" id="importOverlay" style="display:none;">
+    <div class="modal">
+      <div class="mHead">
+        <div class="mTitle" data-i18n="builder.import.title">Importuj</div>
+        <button class="btn sm" id="btnCancelImport" type="button" aria-label="Zamknij">✕</button>
+      </div>
+
+      <div class="importRow" style="margin-top:8px">
+        <input id="importFile" class="inp" type="file" accept=".famgame,.json,application/json">
+      </div>
+
+      <!-- Podgląd / błąd po wczytaniu pliku -->
+      <div id="importPreview" style="display:none;margin-top:10px;padding:10px 12px;border-radius:10px;border:1px solid rgba(255,255,255,.12);font-size:.88rem;display:grid;gap:4px"></div>
+      <div id="importErr" style="display:none;margin-top:8px;color:#f87171;font-size:.88rem"></div>
+
+      <!-- Pasek postępu (podczas importu) -->
+      <div id="importProg" style="display:none;margin-top:12px;gap:10px">
+        <div class="importRow" style="align-items:center">
+          <div id="importProgStep" style="font-weight:800;letter-spacing:.04em">—</div>
+          <div id="importProgCount" style="margin-left:auto;opacity:.8">0/0</div>
+        </div>
+        <div style="height:10px;border-radius:999px;background:rgba(255,255,255,.10);overflow:hidden">
+          <div id="importProgBar" style="height:100%;width:0%;background:rgba(255,255,255,.85)"></div>
+        </div>
+        <div class="importMsg" id="importProgMsg" style="min-height:18px"></div>
+      </div>
+
+      <div class="importRow" style="margin-top:12px">
+        <button class="btn sm gold" id="btnImportJson" type="button" disabled data-i18n="builder.import.confirm">Importuj</button>
+        <div class="importMsg" id="importMsg"></div>
+      </div>
+    </div>
+  </div>
+  <!-- Modal: eksport do bazy pytań -->
+  <div class="overlay" id="exportBaseOverlay" style="display:none;">
+    <div class="modal">
+      <div class="mHead">
+        <div class="mTitle" data-i18n="builder.exportBase.title">Eksport do bazy</div>
+        <button class="btn sm" id="btnExportBaseCancel" type="button" aria-label="Zamknij">✕</button>
+      </div>
+      <div class="mSub">
+        <span data-i18n="builder.exportBase.subtitle">Wybierz bazę pytań. Zostanie utworzony folder w głównym katalogu o nazwie jak gra.</span>
+      </div>
+
+      <div class="ui-select" id="baseSelectWrap" style="margin-top:12px;width:100%;">
+        <button class="btn sm ui-select-btn" type="button" aria-haspopup="listbox" aria-expanded="false">
+          <span class="ui-select-label">—</span>
+          <span class="ui-select-caret" aria-hidden="true">▾</span>
+        </button>
+        <div class="ui-select-menu" role="listbox"></div>
+      </div>
+
+      <!-- PROGRES: export do bazy (ukryty, pokazuje się tylko podczas exportu) -->
+      <div id="exportBaseProg" style="display:none;margin-top:12px;gap:10px">
+        <div class="importRow" style="align-items:center">
+          <div id="exportBaseProgStep" style="font-weight:800;letter-spacing:.04em">—</div>
+          <div id="exportBaseProgCount" style="margin-left:auto;opacity:.8">0/0</div>
+        </div>
+
+        <div style="height:10px;border-radius:999px;background:rgba(255,255,255,.10);overflow:hidden">
+          <div id="exportBaseProgBar" style="height:100%;width:0%;background:rgba(255,255,255,.85)"></div>
+        </div>
+
+        <div class="importMsg" id="exportBaseProgMsg" style="min-height:18px"></div>
+      </div>
+
+      <div class="importRow" style="margin-top:10px;">
+        <button class="btn sm gold" id="btnExportBaseDo" type="button" data-i18n="builder.exportBase.confirm">Eksportuj</button>
+        <div class="importMsg" id="exportBaseMsg"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- EXPORT DO PLIKU: PROGRES -->
+  <div class="overlay" id="exportJsonOverlay" style="display:none;">
+    <div class="modal" style="width:min(640px,94vw)">
+      <div class="mTitle" data-i18n="builder.exportFile.title">EKSPORT…</div>
+      <div class="mSub" id="exportJsonSub" data-i18n="builder.exportFile.subtitle">Nie zamykaj strony. Trwa przygotowanie pliku.</div>
+
+      <div style="margin-top:12px;display:grid;gap:10px">
+        <div class="importRow" style="align-items:center">
+          <div id="exportJsonStep" style="font-weight:800;letter-spacing:.04em">—</div>
+          <div id="exportJsonCount" style="margin-left:auto;opacity:.8">0/0</div>
+        </div>
+
+        <div style="height:10px;border-radius:999px;background:rgba(255,255,255,.10);overflow:hidden">
+          <div id="exportJsonBar" style="height:100%;width:0%;background:rgba(255,255,255,.85)"></div>
+        </div>
+
+        <div class="importMsg" id="exportJsonMsg" style="min-height:18px"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Modal: podgląd gry -->
+  <div class="overlay" id="previewOverlay" style="display:none;">
+    <div class="modal bld-preview-modal">
+      <div class="bld-preview-head">
+        <div class="mTitle" id="previewTitle">—</div>
+        <button class="btn sm" id="btnPreviewClose" type="button" aria-label="Zamknij">✕</button>
+      </div>
+      <div class="bld-preview-questions" id="previewQuestions"></div>
+    </div>
+  </div>
+
+  <!-- Modal: zmiana nazwy -->
+  <div class="overlay" id="nameOverlay" style="display:none;">
+    <div class="modal">
+      <div class="mTitle" id="nameTitle" data-i18n="builder.nameModal.title">Zmień nazwę</div>
+      <div class="mSub" id="nameSub" data-i18n="builder.nameModal.sub">Podaj nową nazwę gry.</div>
+
+      <div class="importRow">
+        <input id="nameInp" class="inp" type="text" maxlength="80" placeholder="Nazwa..." data-i18n-placeholder="builder.nameModal.placeholder"/>
+      </div>
+
+      <div class="importRow">
+        <button class="btn sm gold" id="btnNameOk" type="button" data-i18n="builder.common.save">Zapisz</button>
+        <button class="btn sm" id="btnNameCancel" type="button" data-i18n="builder.common.cancel">Anuluj</button>
+        <div class="importMsg" id="nameMsg"></div>
+      </div>
+    </div>
+  </div>
+
+</body>
+</html>

--- a/control-new.html
+++ b/control-new.html
@@ -406,7 +406,6 @@
                     <button class="btn gold" id="btnUnlockAudio" type="button" data-i18n="control.audioUnlockBtn">🔊 Odblokuj</button>
                     <div class="badge bad" id="audioStatus" data-i18n="control.audioBlocked">ZABLOKOWANE</div>
                   </div>
-                </div>
 
                   <!-- Zaawansowane ustawienia dźwięku — w tej samej karcie -->
                   <div class="sfx-advanced-section">

--- a/control-new.html
+++ b/control-new.html
@@ -408,40 +408,39 @@
                   </div>
                 </div>
 
+                  <!-- Zaawansowane ustawienia dźwięku — w tej samej karcie -->
+                  <div class="sfx-advanced-section">
+                    <button class="sfx-advanced-toggle" id="btnSfxAdvanced" type="button">
+                      <span class="sfx-toggle-arrow">▶</span>
+                      <span data-i18n="control.sfxAdvanced">Zaawansowane</span>
+                    </button>
+
+                    <div class="sfx-advanced-body hidden" id="sfxAdvancedBody">
+                      <div class="sfx-table" id="sfxTable">
+                        <!-- wiersze generowane dynamicznie przez JS -->
+                      </div>
+
+                      <div class="sfx-advanced-foot">
+                        <button class="btn" id="btnSfxReset" type="button"
+                          data-i18n="control.sfxResetAll">Przywróć domyślne</button>
+
+                        <label class="sfx-save-check hidden" id="sfxSaveWrap">
+                          <input type="checkbox" id="chkSfxSave"/>
+                          <span data-i18n="control.sfxSaveCloud">Zapisz w chmurze</span>
+                        </label>
+                        <button class="btn gold hidden" id="btnSfxSave" type="button"
+                          data-i18n="control.sfxSaveBtn">Zapisz</button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
                 <div class="stepFoot step-foot-spaced">
                   <div class="stepFootButtons">
                     <button class="btn" id="btnAudioBack" type="button" data-i18n="common.back">Wstecz</button>
                     <button class="btn gold" id="btnDevicesFinish" type="button" disabled data-i18n="control.devicesFinish">Gotowe — przejdź dalej</button>
                   </div>
                   <div class="msg msg-pill" id="msgAudio"></div>
-                </div>
-              </div>
-
-              <!-- Zaawansowane ustawienia dźwięku -->
-              <div class="card sfx-advanced-card">
-                <div class="cardBody">
-                  <button class="sfx-advanced-toggle" id="btnSfxAdvanced" type="button">
-                    <span class="sfx-toggle-arrow">▶</span>
-                    <span data-i18n="control.sfxAdvanced">Zaawansowane</span>
-                  </button>
-
-                  <div class="sfx-advanced-body hidden" id="sfxAdvancedBody">
-                    <div class="sfx-table" id="sfxTable">
-                      <!-- wiersze generowane dynamicznie przez JS -->
-                    </div>
-
-                    <div class="sfx-advanced-foot">
-                      <button class="btn" id="btnSfxReset" type="button"
-                        data-i18n="control.sfxResetAll">Przywróć domyślne</button>
-
-                      <label class="sfx-save-check hidden" id="sfxSaveWrap">
-                        <input type="checkbox" id="chkSfxSave"/>
-                        <span data-i18n="control.sfxSaveCloud">Zapisz w chmurze</span>
-                      </label>
-                      <button class="btn gold hidden" id="btnSfxSave" type="button"
-                        data-i18n="control.sfxSaveBtn">Zapisz</button>
-                    </div>
-                  </div>
                 </div>
               </div>
             </div>

--- a/control-new/control.css
+++ b/control-new/control.css
@@ -2272,8 +2272,10 @@
 
 /* ===== SFX ADVANCED ===== */
 
-.sfx-advanced-card {
-  margin-top: 12px;
+.sfx-advanced-section {
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(255,255,255,.1);
 }
 
 .sfx-advanced-toggle {

--- a/control-new/control.css
+++ b/control-new/control.css
@@ -2312,6 +2312,7 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
+  overflow: visible;
 }
 
 .sfx-row {
@@ -2321,6 +2322,7 @@
   gap: 10px;
   padding: 6px 0;
   border-bottom: 1px solid rgba(255,255,255,.07);
+  position: relative;
 }
 
 .sfx-row:last-child {
@@ -2334,11 +2336,18 @@
 
 .sfx-variant-wrap {
   display: flex;
-  min-width: 110px;
+  min-width: 0;
+  position: relative;
+  z-index: 1;
 }
 
 .sfx-variant-wrap .ui-select {
   width: 100%;
+  min-width: 0;
+}
+
+.sfx-variant-wrap .ui-select.open {
+  z-index: 10;
 }
 
 .sfx-variant-wrap .ui-select.disabled,

--- a/control-new/js/app.js
+++ b/control-new/js/app.js
@@ -1271,7 +1271,7 @@ async function sendZeroStatesToDevices() {
             <div class="ui-select-menu" role="listbox">${optionsHtml}</div>
           </div>
         </div>
-        <button class="sfx-preview-btn" type="button" title="Podgląd" data-sfx-preview="${key}">🔊</button>
+        <button class="sfx-preview-btn" type="button" title="Odtwórz" data-sfx-preview="${key}">▶</button>
         <div class="sfx-vol-wrap">
           <input type="range" class="sfx-vol" min="0" max="100" value="${volPct}" data-sfx-vol="${key}"/>
           <span class="sfx-vol-label" id="sfxVolLabel_${key}">${volPct}%</span>
@@ -1453,9 +1453,9 @@ async function sendZeroStatesToDevices() {
   document.getElementById("btnSfxReset")?.addEventListener("click", async () => {
     const ok = await confirmModal({
       title: t("control.sfxResetAll"),
-      text: t("common.confirmDefault") || "Przywrócić domyślne ustawienia dźwięku?",
+      text: t("control.sfxResetConfirm"), // klucz zdefiniowany w pl/en/uk
       okText: t("control.sfxResetAll"),
-      cancelText: t("common.cancel") || "Anuluj",
+      cancelText: t("common.cancel"),
     });
     if (!ok) return;
 

--- a/js/core/sfx-new.js
+++ b/js/core/sfx-new.js
@@ -1,5 +1,6 @@
-// js/core/sfx-new.js — sandbox rozszerzenia sfx.js
-// Dodaje: manifest z audio_new/sounds.json, warianty, głośności, custom blob URL, IndexedDB
+// js/core/sfx-new.js
+// Kopia sfx.js z rozszerzeniami: manifest, warianty, głośności, custom blob, cloud URL.
+// Plik samodzielny — nie importuje sfx.js.
 
 const MANIFEST_PATH = "../audio_new/sounds.json?v=v2026-06-03T21150";
 const AUDIO_BASE    = "../audio_new/";
@@ -8,9 +9,9 @@ const IDB_STORE     = "custom-files";
 const LS_VOL_PREFIX = "sfx_vol_";
 const LS_VAR_PREFIX = "sfx_variant_";
 
-// ===================== MANIFEST =====================
+/* ========= MANIFEST ========= */
 
-let manifest = null; // tablica categories po załadowaniu
+let manifest = null;
 
 export async function loadSfxManifest() {
   if (manifest) return manifest;
@@ -24,11 +25,15 @@ export function getSfxCategories() {
   return manifest || [];
 }
 
+export function listSfx() {
+  return getSfxCategories().map(c => c.key);
+}
+
 function getCategoryMeta(key) {
   return (manifest || []).find(c => c.key === key) || null;
 }
 
-// ===================== CACHE AUDIO =====================
+/* ========= CACHE AUDIO ========= */
 
 const cache = new Map(); // key → Audio
 
@@ -49,7 +54,7 @@ function loadIntoCache(key, url) {
   return a;
 }
 
-// ===================== WARIANTY =====================
+/* ========= WARIANTY ========= */
 
 export function getSfxVariant(key) {
   return localStorage.getItem(LS_VAR_PREFIX + key) || "classic.mp3";
@@ -71,7 +76,7 @@ export function resetSfxVariants() {
   }
 }
 
-// ===================== GŁOŚNOŚCI =====================
+/* ========= GŁOŚNOŚCI ========= */
 
 export function getSfxVolume(key) {
   const v = localStorage.getItem(LS_VOL_PREFIX + key);
@@ -112,7 +117,7 @@ export function resetSfxVolumes() {
   }
 }
 
-// ===================== CUSTOM BLOB (IndexedDB) =====================
+/* ========= CUSTOM BLOB (IndexedDB) ========= */
 
 function openIDB() {
   return new Promise((resolve, reject) => {
@@ -159,7 +164,6 @@ export async function clearSfxCustomFile(key) {
   const old = cache.get(key);
   if (old?.src?.startsWith("blob:")) URL.revokeObjectURL(old.src);
 
-  // wróć do aktywnego wariantu
   const meta = getCategoryMeta(key);
   if (meta) {
     loadIntoCache(key, buildUrl(meta.folder, getSfxVariant(key)));
@@ -181,29 +185,7 @@ export async function clearAllSfxCustomFiles() {
   }
 }
 
-// ===================== DŁUGOŚĆ DŹWIĘKU =====================
-
-const durationPromises = new Map();
-
-export function getSfxDuration(key) {
-  if (durationPromises.has(key)) return durationPromises.get(key);
-  const a = cache.get(key);
-  if (!a) {
-    const p = Promise.resolve(0);
-    durationPromises.set(key, p);
-    return p;
-  }
-  const p = new Promise(resolve => {
-    if (!Number.isNaN(a.duration) && a.duration > 0) { resolve(a.duration); return; }
-    const onMeta = () => { a.removeEventListener("loadedmetadata", onMeta); resolve(a.duration || 0); };
-    a.addEventListener("loadedmetadata", onMeta);
-    setTimeout(() => { a.removeEventListener("loadedmetadata", onMeta); resolve(a.duration || 0); }, 5000);
-  });
-  durationPromises.set(key, p);
-  return p;
-}
-
-// ===================== CLOUD URL =====================
+/* ========= CLOUD URL ========= */
 
 export function loadSfxFromCloud(urlMap) {
   for (const [key, url] of urlMap) {
@@ -212,7 +194,7 @@ export function loadSfxFromCloud(urlMap) {
   }
 }
 
-// ===================== ODTWARZANIE =====================
+/* ========= PROSTE ODTWARZANIE ========= */
 
 export function playSfx(key) {
   const a = cache.get(key);
@@ -223,6 +205,8 @@ export function playSfx(key) {
   } catch {}
 }
 
+/* ========= MIKSER / ŚLEDZENIE CZASU ========= */
+
 export function createSfxMixer() {
   let audio = null;
   let raf = null;
@@ -230,7 +214,9 @@ export function createSfxMixer() {
 
   function notify() {
     if (!audio) return;
-    for (const fn of listeners) fn(audio.currentTime || 0, audio.duration || 0);
+    const t = audio.currentTime || 0;
+    const d = audio.duration || 0;
+    for (const fn of listeners) fn(t, d);
   }
 
   function tick() {
@@ -254,34 +240,41 @@ export function createSfxMixer() {
       audio = null;
     },
     onTime(fn) { listeners.add(fn); return () => listeners.delete(fn); },
-    get time() { return audio?.currentTime || 0; },
+    get time() { return audio ? audio.currentTime : 0; },
     get duration() { return audio?.duration || 0; },
   };
 }
 
-// ===================== INICJALIZACJA =====================
+/* ========= DOKŁADNE MIERZENIE DŁUGOŚCI AUDIO ========= */
+
+const durationPromises = new Map();
 
 /**
- * Wywołać raz przy starcie (po loadSfxManifest):
- * wczytuje zapisane warianty, głośności i custom blobs z IndexedDB
+ * Zwraca Promise z dokładną długością dźwięku w sekundach (float).
+ * Jeśli nie da się odczytać – zwraca 0.
  */
-export async function initSfx() {
-  for (const cat of getSfxCategories()) {
-    const variant = getSfxVariant(cat.key);
-    loadIntoCache(cat.key, buildUrl(cat.folder, variant));
-  }
-  applySfxVolumes();
+export function getSfxDuration(key) {
+  if (durationPromises.has(key)) return durationPromises.get(key);
 
-  // wczytaj custom blobs z IndexedDB
-  const files = await getSfxCustomFiles();
-  for (const [key, { blob }] of files) {
-    const url = URL.createObjectURL(blob);
-    loadIntoCache(key, url);
-    applySfxVolume(key);
+  const a = cache.get(key);
+  if (!a) {
+    const p = Promise.resolve(0);
+    durationPromises.set(key, p);
+    return p;
   }
+
+  const p = new Promise((resolve) => {
+    if (!Number.isNaN(a.duration) && a.duration > 0) { resolve(a.duration); return; }
+    const onMeta = () => { a.removeEventListener("loadedmetadata", onMeta); resolve(a.duration || 0); };
+    a.addEventListener("loadedmetadata", onMeta);
+    setTimeout(() => { a.removeEventListener("loadedmetadata", onMeta); resolve(a.duration || 0); }, 5000);
+  });
+
+  durationPromises.set(key, p);
+  return p;
 }
 
-// ===================== AUDIO UNLOCK =====================
+/* ========= AUDIO UNLOCK (gesture) ========= */
 
 let unlocked = false;
 
@@ -298,3 +291,22 @@ export function unlockAudio() {
 }
 
 export function isAudioUnlocked() { return unlocked; }
+
+/* ========= INICJALIZACJA ========= */
+
+/**
+ * Wywołać raz przy starcie (po loadSfxManifest):
+ * wczytuje zapisane warianty, głośności i custom blobs z IndexedDB.
+ */
+export async function initSfx() {
+  for (const cat of getSfxCategories()) {
+    loadIntoCache(cat.key, buildUrl(cat.folder, getSfxVariant(cat.key)));
+  }
+  applySfxVolumes();
+
+  const customFiles = await getSfxCustomFiles();
+  for (const [key, { blob }] of customFiles) {
+    loadIntoCache(key, URL.createObjectURL(blob));
+    applySfxVolume(key);
+  }
+}

--- a/js/core/sfx-new.js
+++ b/js/core/sfx-new.js
@@ -42,6 +42,7 @@ function loadIntoCache(key, url) {
     try { old.pause(); } catch {}
     if (old.src.startsWith("blob:")) URL.revokeObjectURL(old.src);
   }
+  durationPromises.delete(key);
   const a = new Audio(url);
   a.preload = "auto";
   cache.set(key, a);
@@ -178,6 +179,28 @@ export async function clearAllSfxCustomFiles() {
   for (const cat of getSfxCategories()) {
     await clearSfxCustomFile(cat.key);
   }
+}
+
+// ===================== DŁUGOŚĆ DŹWIĘKU =====================
+
+const durationPromises = new Map();
+
+export function getSfxDuration(key) {
+  if (durationPromises.has(key)) return durationPromises.get(key);
+  const a = cache.get(key);
+  if (!a) {
+    const p = Promise.resolve(0);
+    durationPromises.set(key, p);
+    return p;
+  }
+  const p = new Promise(resolve => {
+    if (!Number.isNaN(a.duration) && a.duration > 0) { resolve(a.duration); return; }
+    const onMeta = () => { a.removeEventListener("loadedmetadata", onMeta); resolve(a.duration || 0); };
+    a.addEventListener("loadedmetadata", onMeta);
+    setTimeout(() => { a.removeEventListener("loadedmetadata", onMeta); resolve(a.duration || 0); }, 5000);
+  });
+  durationPromises.set(key, p);
+  return p;
 }
 
 // ===================== CLOUD URL =====================

--- a/js/pages/builder-new.js
+++ b/js/pages/builder-new.js
@@ -1,0 +1,1766 @@
+import { addRenameGesture } from "../core/rename-gesture.js?v=v2026-06-03T21150";
+import { sb } from "../core/supabase.js?v=v2026-06-03T21150";
+import { requireAuth } from "../core/auth.js?v=v2026-06-03T21150";
+import { alertModal, confirmModal } from "../core/modal.js?v=v2026-06-03T21150";
+import { hideForGuest, isGuestUser } from "../core/guest-mode.js?v=v2026-06-03T21150";
+import { initI18n, t, applyTranslations } from "../../translation/translation.js?v=v2026-06-03T21150";
+import { initRatingSystem } from "../core/rating-system.js?v=v2026-06-03T21150";
+import { initUiSelect } from "../core/ui-select.js?v=v2026-06-03T21150";
+import { maybeShowGuestInfoModal } from "../core/guest-info-modal.js?v=v2026-06-03T21150";
+
+import { initPwa, isStandalone, isMobileDevice } from "../core/pwa.js?v=v2026-06-03T21150";
+
+// Zarejestruj listener PWA jak najwcześniej – beforeinstallprompt może odpalić przed requireAuth
+const pwaApi = initPwa();
+// Jeśli beforeinstallprompt już odpalił zanim dodaliśmy listener w IIFE, sprawdzimy po zalogowaniu
+
+
+import { exportGame, importGame, downloadJson } from "./builder-import-export.js?v=v2026-06-03T21150";
+import { setTopbarNavPriority, setTopbarAccount } from '../core/topbar-controller.js?v=v2026-06-03T21150';
+
+import "../core/contact-modal.js";
+import {
+  TYPES,
+  STATUS,
+  loadGameBasic,
+  canEnterEdit,
+  validateGameReadyToPlay,
+  validatePollEntry,
+  validatePollReadyToOpen,
+} from "../core/game-validate.js?v=v2026-06-03T21150";
+
+const MSG = {
+  exportBaseEmpty: () => t("builder.exportBase.empty"),
+  exportBaseMetaOwned: () => t("builder.exportBase.metaOwned"),
+  exportBaseMetaShared: () => t("builder.exportBase.metaShared"),
+  exportBaseBaseFallback: () => t("builder.exportBase.baseFallback"),
+  gameFallback: () => t("builder.gameFallback"),
+  typePollText: () => t("builder.types.pollText"),
+  typePollPoints: () => t("builder.types.pollPoints"),
+  typePrepared: () => t("builder.types.prepared"),
+  typeMarket: () => t("builder.types.market"),
+  statusDraft: () => t("builder.status.draft"),
+  statusOpen: () => t("builder.status.open"),
+  statusClosed: () => t("builder.status.closed"),
+  newGamePollText: () => t("builder.newGame.pollText"),
+  newGamePollPoints: () => t("builder.newGame.pollPoints"),
+  newGamePrepared: () => t("builder.newGame.prepared"),
+  deleteTitle: () => t("builder.delete.title"),
+  deleteText: (name) => t("builder.delete.text", { name }),
+  deleteOk: () => t("builder.delete.ok"),
+  deleteCancel: () => t("builder.delete.cancel"),
+  alertDeleteFailed: () => t("builder.alert.deleteFailed"),
+  alertCreateFailed: () => t("builder.alert.createFailed"),
+  hintSelect: () => t("builder.hint.select"),
+  hintSelectPlus: () => t("builder.hint.selectPlus"),
+  alertResetPollFailed: () => t("builder.alert.resetPollFailed"),
+  alertCheckFailed: () => t("builder.alert.checkFailed"),
+  alertOpenPollFailed: () => t("builder.alert.openPollFailed"),
+  exportJsonSub: () => t("builder.exportFile.subtitle"),
+  exportStart: () => t("builder.exportFile.progress.start"),
+  exportFetch: () => t("builder.exportFile.progress.fetch"),
+  exportDone: () => t("builder.exportFile.progress.done"),
+  exportDownload: () => t("builder.exportFile.progress.download"),
+  exportErrorLabel: () => t("builder.exportFile.progress.errorLabel"),
+  exportFailed: () => t("builder.exportFile.progress.failed"),
+  exportBaseLoadFailed: () => t("builder.exportBase.loadFailed"),
+  exportBasePick: () => t("builder.exportBase.pickBase"),
+  exportBaseStart: () => t("builder.exportBase.progress.start"),
+  exportBaseStep: () => t("builder.exportBase.progress.step"),
+  exportBaseDone: () => t("builder.exportBase.progress.done"),
+  exportBaseSaved: () => t("builder.exportBase.progress.saved"),
+  exportBaseFailed: () => t("builder.exportBase.progress.failed"),
+  exportBaseErrorLabel: () => t("builder.exportBase.progress.errorLabel"),
+  importPickFile: () => t("builder.import.pickFile"),
+  importLoaded: () => t("builder.import.loaded"),
+  importLoadFailed: () => t("builder.import.loadFailed"),
+  importPasteJson: () => t("builder.import.pasteJson"),
+  importInvalidJson: () => t("builder.import.invalidJson"),
+  importStart: () => t("builder.import.progress.start"),
+  importSave: () => t("builder.import.progress.save"),
+  importDone: () => t("builder.import.progress.done"),
+  importErrorLabel: () => t("builder.import.progress.errorLabel"),
+  importFailed: () => t("builder.import.progress.failed"),
+  importDbFailed: () => t("builder.import.dbFailed"),
+  exportBaseFolderStep: () => t("builder.exportBase.progress.folder"),
+  exportBaseQuestionsStep: () => t("builder.exportBase.progress.questions"),
+};
+
+/* ================= DOM ================= */
+const grid = document.getElementById("grid");
+const whoStatic = document.getElementById("whoStatic");
+const hint = document.getElementById("hint");
+
+const btnLogout = document.getElementById("btnLogout");
+const btnInstall = document.getElementById("btnInstall");
+const btnEdit = document.getElementById("btnEdit");
+const btnPreview = document.getElementById("btnPreview");
+const btnPlay = document.getElementById("btnPlay");
+const btnPoll = document.getElementById("btnPoll");
+
+const btnManual = document.getElementById("btnManual");
+const btnLogoEditor = document.getElementById("btnLogoEditor");
+const btnBases = document.getElementById("btnBases");
+const btnPollsHub = document.getElementById("btnPollsHub");
+const pollsHubBadge = document.getElementById("pollsHubBadge");
+const btnSubscriptionsHub = document.getElementById("btnSubscriptionsHub");
+const subscriptionsHubBadge = document.getElementById("subscriptionsHubBadge");
+const navMore = document.getElementById("navMore");
+const btnMore = document.getElementById("btnMore");
+const navMoreDropdown = document.getElementById("navMoreDropdown");
+
+const btnExport = document.getElementById("btnExport");
+const btnImport = document.getElementById("btnImport");
+const btnExportBase = document.getElementById("btnExportBase");
+
+// Modal eksportu do bazy
+const exportBaseOverlay = document.getElementById("exportBaseOverlay");
+const baseSelectWrap = document.getElementById("baseSelectWrap");
+const btnExportBaseDo = document.getElementById("btnExportBaseDo");
+const btnExportBaseCancel = document.getElementById("btnExportBaseCancel");
+const exportBaseMsg = document.getElementById("exportBaseMsg");
+
+let baseSelectApi = null; // ui-select API
+
+// Export base progress (w modalu eksportu do bazy)
+const exportBaseProg = document.getElementById("exportBaseProg");
+const exportBaseProgStep = document.getElementById("exportBaseProgStep");
+const exportBaseProgCount = document.getElementById("exportBaseProgCount");
+const exportBaseProgBar = document.getElementById("exportBaseProgBar");
+const exportBaseProgMsg = document.getElementById("exportBaseProgMsg");
+
+// Tabs
+const tabPollText = document.getElementById("tabPollText");
+const tabPollPoints = document.getElementById("tabPollPoints");
+const tabPrepared = document.getElementById("tabPrepared");
+const tabMarket = document.getElementById("tabMarket");
+const btnMarketplace = document.getElementById("btnMarketplace");
+const btnConnectDevice = document.getElementById("btnConnectDevice");
+const connectDeviceBadge = document.getElementById("connectDeviceBadge");
+
+// Modal importu JSON
+const importOverlay = document.getElementById("importOverlay");
+const importFile = document.getElementById("importFile");
+const btnImportJson = document.getElementById("btnImportJson");
+const btnCancelImport = document.getElementById("btnCancelImport");
+const importPreview = document.getElementById("importPreview");
+const importErr = document.getElementById("importErr");
+const importMsg = document.getElementById("importMsg");
+
+// Import progress (w modalu importu)
+const importProg = document.getElementById("importProg");
+const importProgStep = document.getElementById("importProgStep");
+const importProgCount = document.getElementById("importProgCount");
+const importProgBar = document.getElementById("importProgBar");
+const importProgMsg = document.getElementById("importProgMsg");
+
+// Export do pliku progress (osobny overlay)
+const exportJsonOverlay = document.getElementById("exportJsonOverlay");
+const exportJsonSub = document.getElementById("exportJsonSub");
+const exportJsonStep = document.getElementById("exportJsonStep");
+const exportJsonCount = document.getElementById("exportJsonCount");
+const exportJsonBar = document.getElementById("exportJsonBar");
+const exportJsonMsg = document.getElementById("exportJsonMsg");
+
+// Modal zmiany nazwy
+const nameOverlay = document.getElementById("nameOverlay");
+const nameTitle = document.getElementById("nameTitle");
+const nameSub = document.getElementById("nameSub");
+const nameInp = document.getElementById("nameInp");
+const btnNameOk = document.getElementById("btnNameOk");
+const btnNameCancel = document.getElementById("btnNameCancel");
+const nameMsg = document.getElementById("nameMsg");
+
+/* ================= STATE ================= */
+let currentUser = null;
+let gamesAll = [];
+let selectedId = null;
+let marketGamesAll = [];
+let selectedMarketId = null;
+
+let renamingGameId = null;
+let nameMode = "rename"; // "rename" | "create"
+let creatingUiType = null;
+
+// =======================================================
+// Auto-refresh (jak polls-hub)
+// - co 20s
+// - tylko gdy karta widoczna
+// - nie odświeżaj gdy overlay/progress jest otwarty
+// =======================================================
+let autoRefreshTimer = null;
+let builderRefreshInFlight = null;
+
+function anyOverlayOpen() {
+  const ovs = [importOverlay, exportBaseOverlay, exportJsonOverlay, nameOverlay];
+  return ovs.some((ov) => ov && (ov.style.display === "grid" || ov.style.display === "block" || ov.style.display === ""));
+}
+
+async function refreshView() {
+  if (builderRefreshInFlight) return builderRefreshInFlight;
+  builderRefreshInFlight = (async () => {
+    await refresh();
+  })();
+  try {
+    await builderRefreshInFlight;
+  } finally {
+    builderRefreshInFlight = null;
+  }
+}
+
+function startAutoRefresh() {
+  if (autoRefreshTimer) return;
+  autoRefreshTimer = setInterval(() => {
+    if (document.hidden) return;
+    if (anyOverlayOpen()) return;
+    void refreshView();
+  }, 20000);
+}
+
+function stopAutoRefresh() {
+  if (!autoRefreshTimer) return;
+  clearInterval(autoRefreshTimer);
+  autoRefreshTimer = null;
+}
+
+// DOMYŚLNIE: PREPAROWANA
+let activeTab = TYPES.PREPARED;
+
+const actionStateCache = new Map(); 
+// gameId -> { rev: string, res: { canEdit, canPlay, canPoll, canExport, needsResetWarning } }
+
+/* ================= UI helpers ================= */
+function show(el, on) {
+  if (!el) return;
+  el.style.display = on ? "" : "none";
+}
+
+function isIOSSafari() {
+  const ua = navigator.userAgent || "";
+  const iOS =
+    /iPad|iPhone|iPod/.test(ua) ||
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+  const webkit = /WebKit/.test(ua);
+  const notChrome = !/CriOS|FxiOS|EdgiOS/.test(ua);
+  return iOS && webkit && notChrome;
+}
+
+function tSafe(key, fallback) {
+  const v = t(key);
+  return v === key ? fallback : v;
+}
+
+const IOS_PROMPT_LS_KEY = "pwa:install_dismissed";
+
+async function maybeShowIosWebappPrompt() {
+  if (!isIOSSafari() || window.navigator.standalone) return;
+  if (localStorage.getItem(IOS_PROMPT_LS_KEY)) return;
+
+  const fallback = {
+    title: "Dodaj Familiadę do ekranu głównego",
+    text:
+      "Dla najlepszego komfortu użytkowania zalecamy korzystać z aplikacji webowej. Żeby to zrobić:\n" +
+      "1. Otwórz menu Udostępnij.\n" +
+      "2. Wybierz \u201eDo ekranu początkowego\u201d.\n" +
+      "3. Zatwierdź dodanie.\n" +
+      "4. Uruchom Familiadę z nowej ikony na ekranie głównym.",
+    ok: "OK",
+    never: "Nie pokazuj więcej",
+  };
+
+  let skipNextTime = false;
+  await confirmModal({
+    title: tSafe("builder.iosWebapp.title", fallback.title),
+    text: tSafe("builder.iosWebapp.text", fallback.text),
+    okText: tSafe("builder.iosWebapp.ok", fallback.ok),
+    cancelText: tSafe("builder.iosWebapp.never", fallback.never),
+    onReady: ({ cancelBtn }) => {
+      cancelBtn?.addEventListener("click", () => { skipNextTime = true; }, { once: true });
+    },
+  });
+
+  if (skipNextTime) localStorage.setItem(IOS_PROMPT_LS_KEY, "1");
+}
+
+
+function setProgUi(stepEl, countEl, barEl, msgEl, { step, i, n, msg, isError } = {}) {
+  if (stepEl && step != null) stepEl.textContent = String(step);
+  if (countEl) countEl.textContent = `${Number(i) || 0}/${Number(n) || 0}`;
+
+  const nn = Number(n) || 0;
+  const ii = Number(i) || 0;
+  const pct = nn > 0 ? Math.round((ii / nn) * 100) : 0;
+  if (barEl) barEl.style.width = `${Math.max(0, Math.min(100, pct))}%`;
+
+  if (msgEl) {
+    msgEl.textContent = msg ? String(msg) : "";
+    msgEl.style.opacity = isError ? "1" : ".85";
+  }
+}
+
+function showProgBlock(el, on) {
+  if (!el) return;
+  // Domyślnie w HTML jest display:none; chcemy grid w trakcie
+  el.style.display = on ? "grid" : "none";
+}
+
+function setHint(t) {
+  if (!hint) return;
+  hint.textContent = t || "";
+}
+
+function setImportMsg(t) {
+  if (!importMsg) return;
+  importMsg.textContent = t || "";
+}
+
+let importParsed = null; // aktualnie sparsowany obiekt gry
+
+function importResetPreview() {
+  importParsed = null;
+  if (importPreview) { importPreview.style.display = "none"; importPreview.innerHTML = ""; }
+  if (importErr) { importErr.style.display = "none"; importErr.textContent = ""; }
+  if (btnImportJson) btnImportJson.disabled = true;
+}
+
+function openImportModal() {
+  importResetPreview();
+  if (importFile) importFile.value = "";
+  setImportMsg("");
+  showProgBlock(importProg, false);
+  show(importOverlay, true);
+}
+function closeImportModal() { show(importOverlay, false); }
+
+function setNameMsg(t) {
+  if (!nameMsg) return;
+  nameMsg.textContent = t || "";
+}
+
+function openRenameModal(game) {
+  if (!game) return;
+  nameMode = "rename";
+  renamingGameId = game.id;
+  setNameMsg("");
+  if (nameTitle) nameTitle.textContent = t("builder.nameModal.title");
+  if (nameSub) nameSub.textContent = t("builder.nameModal.sub");
+  if (nameInp) nameInp.value = game.name || "";
+  show(nameOverlay, true);
+  setTimeout(() => nameInp?.select(), 0);
+}
+
+function openCreateModal(uiType) {
+  nameMode = "create";
+  creatingUiType = uiType;
+  setNameMsg("");
+  if (nameTitle) nameTitle.textContent = t("builder.nameModal.titleCreate");
+  if (nameSub) nameSub.textContent = t("builder.nameModal.subCreate");
+  if (nameInp) nameInp.value = "";
+  show(nameOverlay, true);
+  setTimeout(() => nameInp?.focus(), 0);
+}
+
+function closeRenameModal() {
+  renamingGameId = null;
+  creatingUiType = null;
+  nameMode = "rename";
+  show(nameOverlay, false);
+}
+
+async function renameGame(gameId, newName) {
+  const val = String(newName || "").trim();
+  if (!val) return;
+
+  const { error } = await sb()
+    .from("games")
+    .update({ name: val })
+    .eq("id", gameId);
+
+  if (error) throw error;
+}
+
+function setExportBaseMsg(t) {
+  if (!exportBaseMsg) return;
+  exportBaseMsg.textContent = t || "";
+}
+
+function openExportBaseModal() {
+  setExportBaseMsg("");
+  show(exportBaseOverlay, true);
+}
+
+function closeExportBaseModal() {
+  show(exportBaseOverlay, false);
+}
+
+function escapeHtml(s) {
+  return String(s ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Bazy do eksportu:
+ * - moje (owner)
+ * - udostępnione z rolą editor (bo eksport = zapis do bazy)
+ */
+async function listExportableBases() {
+  const ownedP = sb()
+    .from("question_bases")
+    .select("id,name,owner_id,updated_at,created_at")
+    .eq("owner_id", currentUser.id)
+    .order("updated_at", { ascending: false });
+
+  const sharedP = sb()
+    .from("question_base_shares")
+    .select("role, base_id, question_bases(id,name,owner_id,updated_at,created_at)")
+    .eq("user_id", currentUser.id)
+    .eq("role", "editor")
+    .order("created_at", { ascending: false });
+
+  const [{ data: owned, error: e1 }, { data: shared, error: e2 }] = await Promise.all([ownedP, sharedP]);
+  if (e1) throw e1;
+  if (e2) throw e2;
+
+  const out = [];
+
+  for (const b of (owned || [])) {
+    out.push({ id: b.id, name: b.name, kind: "owned" });
+  }
+
+  for (const row of (shared || [])) {
+    const b = row.question_bases;
+    if (!b) continue;
+    out.push({ id: b.id, name: b.name, kind: "shared_editor" });
+  }
+
+  // usuń duplikaty, gdyby kiedyś coś się nałożyło
+  const seen = new Set();
+  return out.filter((b) => (seen.has(b.id) ? false : (seen.add(b.id), true)));
+}
+
+function renderBaseSelect(bases) {
+  if (!baseSelectWrap) return;
+  
+  // Zniszcz poprzedni ui-select jeśli istnieje
+  if (baseSelectApi) {
+    baseSelectApi.destroy();
+    baseSelectApi = null;
+  }
+  
+  if (!bases || !bases.length) {
+    // Brak baz - pokaż komunikat
+    baseSelectWrap.style.display = "none";
+    setExportBaseMsg(MSG.exportBaseEmpty());
+    return;
+  }
+  
+  baseSelectWrap.style.display = "";
+  
+  // Przygotuj opcje
+  const options = bases.map(b => ({
+    value: b.id,
+    label: b.name || MSG.gameFallback(),
+  }));
+  
+  // Inicjalizuj ui-select
+  baseSelectApi = initUiSelect(baseSelectWrap, {
+    options,
+    value: options[0]?.value || "",
+    placeholder: MSG.exportBasePick(),
+    onChange: (value) => {
+      // Można dodać walidację jeśli potrzeba
+    },
+  });
+}
+
+function getSelectedBaseId() {
+  return baseSelectApi ? baseSelectApi.getValue() : null;
+}
+
+async function pickUniqueRootFolderName(baseId, desiredName) {
+  const base = String(desiredName || MSG.gameFallback()).trim() || MSG.gameFallback();
+  const base80 = base.slice(0, 80);
+
+  // pobierz nazwy root-folderów z tej bazy
+  const { data, error } = await sb()
+    .from("qb_categories")
+    .select("name")
+    .eq("base_id", baseId)
+    .is("parent_id", null);
+
+  if (error) throw error;
+
+  const used = new Set((data || []).map(r => String(r.name || "").trim()));
+
+  if (!used.has(base80)) return base80;
+
+  // Dodawaj (2), (3)... pilnując limitu 80 znaków
+  for (let n = 2; n < 1000; n++) {
+    const suffix = ` (${n})`;
+    const candidate = base80.slice(0, Math.max(1, 80 - suffix.length)) + suffix;
+    if (!used.has(candidate)) return candidate;
+  }
+
+  // awaryjnie (nie powinno się zdarzyć)
+  return (base80.slice(0, 70) + " (999)").slice(0, 80);
+}
+
+async function exportSelectedGameToBase(baseId, onProgress) {
+  if (!selectedId) return;
+
+  // 1) Pobierz payload gry (już masz działające)
+  let obj = null;
+  obj = await exportGame(selectedId, ({ step, i, n, msg } = {}) => {
+    if (typeof onProgress === "function") {
+      onProgress({ step: step || MSG.exportFetch(), i, n, msg });
+    }
+  });
+  
+  const gameNameRaw = String(obj?.game?.name || MSG.gameFallback()).trim() || MSG.gameFallback();
+  const gameName = await pickUniqueRootFolderName(baseId, gameNameRaw);
+
+  // 2) Utwórz folder w root o nazwie gry
+  // Ustal ord = max(root.ord)+1 (opcjonalnie, ale stabilnie)
+  
+  const { data: lastRoot, error: eLast } = await sb()
+    .from("qb_categories")
+    .select("ord")
+    .eq("base_id", baseId)
+    .is("parent_id", null)
+    .order("ord", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (eLast) throw eLast;
+
+  const nextOrd = (Number(lastRoot?.ord) || 0) + 1;
+
+  if (typeof onProgress === "function") {
+    onProgress({ step: MSG.exportBaseFolderStep(), i: 0, n: 1, msg: "" });
+  }
+  
+  const { data: folder, error: eCat } = await sb()
+    .from("qb_categories")
+    .insert(
+      { base_id: baseId, parent_id: null, name: gameName.slice(0, 80), ord: nextOrd },
+      { defaultToNull: false }
+    )
+    .select("id")
+    .single();
+  if (eCat) throw eCat;
+
+  // 3) Zapisz pytania do tego folderu
+  const qs = Array.isArray(obj?.questions) ? obj.questions : [];
+  const rows = qs.map((q, i) => ({
+    base_id: baseId,
+    category_id: folder.id,
+    ord: i + 1,
+    payload: {
+      text: q?.text || "",
+      answers: Array.isArray(q?.answers) ? q.answers.map((a) => ({
+        text: a?.text || "",
+        fixed_points: Number(a?.fixed_points) || 0,
+      })) : [],
+    },
+  }));
+
+  if (rows.length) {
+    const nQ = rows.length;
+    const CHUNK = 200;
+  
+    if (typeof onProgress === "function") {
+      onProgress({ step: MSG.exportBaseQuestionsStep(), i: 0, n: nQ, msg: "" });
+    }
+  
+    for (let i = 0; i < rows.length; i += CHUNK) {
+      const part = rows.slice(i, i + CHUNK);
+      const { error: eQ } = await sb().from("qb_questions").insert(part, { defaultToNull: false });
+      if (eQ) throw eQ;
+  
+      if (typeof onProgress === "function") {
+        onProgress({
+          step: MSG.exportBaseQuestionsStep(),
+          i: Math.min(i + part.length, nQ),
+          n: nQ,
+          msg: t("builder.exportBase.progress.savedCount", { done: Math.min(i + part.length, nQ), total: nQ }),
+        });
+      }
+    }
+  }
+}
+
+function safeDownloadName(name) {
+  const base = String(name || "familiada")
+    .replace(/[^\w\d\- ]+/g, "")
+    .trim()
+    .slice(0, 40) || "familiada";
+  return `${base}.famgame`;
+}
+
+/**
+ * UI-type (3 zakładki) vs DB-type (często tylko fixed/poll).
+ * - Jeśli masz nową bazę z type = poll_text/poll_points/prepared -> działa wprost.
+ * - Jeśli masz starą bazę z type = fixed/poll ->:
+ *    fixed => prepared
+ *    poll  => poll_text albo poll_points (wnioskujemy po nazwie)
+ */
+function uiTypeFromRow(g) {
+  const k = String(g?.type || "");
+  if (k === TYPES.POLL_TEXT || k === TYPES.POLL_POINTS || k === TYPES.PREPARED || k === TYPES.MARKET) return k;
+  if (k === "fixed") return TYPES.PREPARED;
+  if (k === "poll") {
+    const nm = String(g?.name || "").toLowerCase();
+    return nm.includes("punkt") ? TYPES.POLL_POINTS : TYPES.POLL_TEXT;
+  }
+  return TYPES.PREPARED;
+}
+
+function typeLabel(uiType) {
+  if (uiType === TYPES.POLL_TEXT) return MSG.typePollText();
+  if (uiType === TYPES.POLL_POINTS) return MSG.typePollPoints();
+  if (uiType === TYPES.PREPARED) return MSG.typePrepared();
+  if (uiType === TYPES.MARKET) return MSG.typeMarket();
+  return String(uiType || t("control.dash")).toUpperCase();
+}
+
+function statusLabel(st) {
+  const s = st || STATUS.DRAFT;
+  if (s === STATUS.DRAFT) return MSG.statusDraft();
+  if (s === STATUS.POLL_OPEN) return MSG.statusOpen();
+  if (s === STATUS.READY) return MSG.statusClosed();
+  return String(s).toUpperCase();
+}
+
+function setButtonsState({ hasSel, canEdit, canPlay, canPoll, canExport }) {
+  if (btnEdit) btnEdit.disabled = !hasSel || !canEdit;
+  if (btnPreview) btnPreview.disabled = !hasSel;
+  if (btnPlay) btnPlay.disabled = !hasSel || !canPlay;
+  if (btnPoll) btnPoll.disabled = !hasSel || !canPoll;
+  if (btnExport) btnExport.disabled = !hasSel || !canExport;
+  if (btnExportBase) btnExportBase.disabled = !hasSel || !canExport;
+}
+/* ================= Tabs ================= */
+function setActiveTab(type) {
+  activeTab = type;
+
+  tabPollText?.classList.toggle("active", type === TYPES.POLL_TEXT);
+  tabPollPoints?.classList.toggle("active", type === TYPES.POLL_POINTS);
+  tabPrepared?.classList.toggle("active", type === TYPES.PREPARED);
+  tabMarket?.classList.toggle("active", type === TYPES.MARKET);
+
+  // jeśli zaznaczona gra nie pasuje do zakładki – odznacz
+  if (type !== TYPES.MARKET) {
+    selectedMarketId = null;
+    const sel = gamesAll.find(g => g.id === selectedId);
+    if (sel && uiTypeFromRow(sel) !== activeTab) selectedId = null;
+  } else {
+    selectedId = null;
+  }
+
+  render();
+  updateActionState();
+}
+
+/* ================= DB ================= */
+async function listGames() {
+  const { data, error } = await sb()
+    .from("games")
+    .select("id,name,created_at,updated_at,type,status")
+    .is("source_market_id", null)
+    .order("created_at", { ascending: false });
+
+  if (error) throw error;
+  return data || [];
+}
+
+function defaultNameForUiType(uiType) {
+  if (uiType === TYPES.POLL_TEXT) return MSG.newGamePollText();
+  if (uiType === TYPES.POLL_POINTS) return MSG.newGamePollPoints();
+  return MSG.newGamePrepared();
+}
+
+/**
+ * Tworzenie gry:
+ * - najpierw próbujemy wstawić type = uiType (pod nową bazę)
+ * - jeśli DB ma check fixed/poll (23514), robimy fallback:
+ *    prepared -> fixed, polls -> poll
+ */
+async function createGame(uiType, name) {
+  const gameName = name || defaultNameForUiType(uiType);
+
+  // 1) próbuj nowy schemat (type = poll_text/poll_points/prepared)
+  let ins = await sb()
+    .from("games")
+    .insert({
+      name: gameName,
+      owner_id: currentUser.id,
+      type: uiType,
+      status: STATUS.DRAFT,
+      },
+      { defaultToNull: false }
+    )
+    .select("id,name,type,status")
+    .single();
+
+  if (ins.error) {
+    const code = ins.error?.code;
+    const msg = String(ins.error?.message || "");
+    const isTypeCheck =
+      code === "23514" ||
+      msg.includes("games_type_check") ||
+      msg.includes("violates check constraint");
+
+    if (!isTypeCheck) throw ins.error;
+
+    // 2) fallback pod starą bazę (type = fixed/poll)
+    const dbType = (uiType === TYPES.PREPARED) ? "fixed" : "poll";
+
+    ins = await sb()
+      .from("games")
+      .insert({
+        name: gameName,
+        owner_id: currentUser.id,
+        type: dbType,
+        status: STATUS.DRAFT,
+      },
+      { defaultToNull: false }
+    )
+      .select("id,name,type,status")
+      .single();
+
+    if (ins.error) throw ins.error;
+  }
+
+  const game = ins.data;
+  return game;
+}
+
+async function deleteGame(game) {
+  const ok = await confirmModal({
+    title: MSG.deleteTitle(),
+    text: MSG.deleteText(game.name),
+    okText: MSG.deleteOk(),
+    cancelText: MSG.deleteCancel(),
+  });
+  if (!ok) return;
+
+  const { error } = await sb().from("games").delete().eq("id", game.id);
+  if (error) {
+    console.error("[builder] delete error:", error);
+    void alertModal({ text: MSG.alertDeleteFailed() });
+  }
+}
+
+async function resetPollForEditing(gameId) {
+  const { error: gErr } = await sb()
+    .from("games")
+    .update({ status: STATUS.DRAFT })
+    .eq("id", gameId);
+  if (gErr) throw gErr;
+
+  const { data: qs, error: qErr } = await sb()
+    .from("questions")
+    .select("id")
+    .eq("game_id", gameId);
+
+  if (qErr) throw qErr;
+
+  const qIds = (qs || []).map(x => x.id);
+  if (!qIds.length) return;
+
+  const { error: aErr } = await sb()
+    .from("answers")
+    .update({ fixed_points: 0 })
+    .in("question_id", qIds);
+
+  if (aErr) throw aErr;
+}
+
+/* ================= Render ================= */
+function cardGame(g) {
+  const uiType = uiTypeFromRow(g);
+
+  const el = document.createElement("div");
+  el.className = "card";
+
+  el.innerHTML = `
+    <div class="x" title="${t("builder.card.delete")}">✕</div>
+    <div class="name"></div>
+    <div class="meta"></div>
+  `;
+
+  el.querySelector(".name").textContent = g.name || t("control.dash");
+  el.querySelector(".meta").textContent = `${typeLabel(uiType)} • ${statusLabel(g.status)}`;
+
+  el.addEventListener("click", async () => {
+    selectedId = g.id;
+    render();
+    await updateActionState();
+  });
+
+  addRenameGesture(el, () => {
+    openRenameModal(g);
+  });
+
+  el.querySelector(".x").addEventListener("click", async (e) => {
+    e.stopPropagation();
+    await deleteGame(g);
+    await refresh();
+  });
+
+  return el;
+}
+
+let isCreatingGame = false;
+
+function cardAdd(uiType) {
+  const el = document.createElement("div");
+  el.className = "addCard";
+  el.innerHTML = `
+    <div class="plus">＋</div>
+    <div class="txt">${t("builder.card.newGame")}</div>
+    <div class="sub">${typeLabel(uiType)}</div>
+  `;
+    el.addEventListener("click", () => {
+      openCreateModal(uiType);
+    });
+  return el;
+}
+
+function render() {
+  if (!grid) return;
+  grid.innerHTML = "";
+
+  if (activeTab === TYPES.MARKET) {
+    renderMarket();
+    return;
+  }
+
+  const games = (gamesAll || []).filter(g => uiTypeFromRow(g) === activeTab);
+
+  // pierwszy kafelek: dodawanie w aktualnej zakładce
+  grid.appendChild(cardAdd(activeTab));
+
+  for (const g of games) {
+    const el = cardGame(g);
+    if (g.id === selectedId) el.classList.add("selected");
+    grid.appendChild(el);
+  }
+
+  setButtonsState({
+    hasSel: !!selectedId,
+    canEdit: false,
+    canPlay: false,
+    canPoll: false,
+    canExport: false,
+  });
+
+  setHint(MSG.hintSelectPlus());
+}
+
+function renderMarket() {
+  if (!grid) return;
+  grid.innerHTML = "";
+
+  if (!marketGamesAll.length) {
+    const el = document.createElement("div");
+    el.className = "addCard";
+    el.style.cursor = "default";
+    el.style.pointerEvents = "none";
+    el.innerHTML = `
+      <div class="txt">${t("builder.market.empty")}</div>
+      <div class="sub">${t("builder.market.emptyHint")}</div>
+    `;
+    grid.appendChild(el);
+  }
+
+  for (const g of marketGamesAll) {
+    const el = cardMarket(g);
+    if (g.market_game_id === selectedMarketId) el.classList.add("selected");
+    grid.appendChild(el);
+  }
+
+  setButtonsState({
+    hasSel: !!selectedMarketId,
+    canEdit: false,
+    canPlay: !!selectedMarketId,
+    canPoll: false,
+    canExport: false,
+  });
+
+  setHint(t("builder.market.hint"));
+}
+
+function cardMarket(g) {
+  const el = document.createElement("div");
+  el.className = "card";
+  el.innerHTML = `
+    <div class="name">${escapeHtml(g.title || "—")}</div>
+    <div class="meta">${t("builder.market.typeLabel")} · ${(g.lang || "").toUpperCase()}</div>
+    <div class="x" title="${t("builder.market.removeFromLibrary")}">✕</div>
+  `;
+  el.addEventListener("click", () => {
+    selectedMarketId = g.market_game_id;
+    renderMarket();
+  });
+  el.querySelector(".x").addEventListener("click", async (e) => {
+    e.stopPropagation();
+    const { error } = await sb().rpc("market_remove_from_library", { p_market_game_id: g.market_game_id });
+    if (error) { console.error("[builder] removeFromLibrary error:", error); return; }
+    if (selectedMarketId === g.market_game_id) selectedMarketId = null;
+    marketGamesAll = marketGamesAll.filter(x => x.market_game_id !== g.market_game_id);
+    renderMarket();
+  });
+  return el;
+}
+
+async function loadMarketGames() {
+  try {
+    const { data, error } = await sb().rpc("market_my_library");
+    if (error) throw error;
+    marketGamesAll = data || [];
+  } catch (e) {
+    console.error("[builder] loadMarketGames error:", e);
+    marketGamesAll = [];
+  }
+}
+
+/* ================= Button logic ================= */
+
+function normalizeGameForValidate(g) {
+  if (!g) return g;
+  const type = uiTypeFromRow(g); // mapuje fixed->prepared, poll->poll_text/poll_points
+  return { ...g, type };
+}
+
+async function fetchActionState(gameId, revHint) {
+  // Cache hit tylko gdy znamy rev i się zgadza
+  if (revHint) {
+    const c = actionStateCache.get(gameId);
+    if (c && String(c.rev) === String(revHint)) return c.res;
+  }
+
+  const { data, error } = await sb()
+    .rpc("game_action_state", { p_game_id: gameId })
+    .single();
+
+  if (error) throw error;
+  const res = {
+    canEdit: true, // finalnie i tak liczysz canEnterEdit() w UI, ale tu trzymamy “stan przycisku”
+    needsResetWarning: !!data?.needs_reset_warning,
+    canPlay: !!data?.can_play,
+    canPoll: !!data?.can_poll,
+    canExport: !!data?.can_export,
+    reasonPlay: data?.reason_play || "",
+    reasonPoll: data?.reason_poll || "",
+    rev: String(data?.rev || "")
+  };
+
+
+  actionStateCache.set(gameId, { rev: res.rev, res });
+  return res;
+}
+
+async function updateActionState() {
+  // market tab: buttons controlled by renderMarket directly
+  if (activeTab === TYPES.MARKET) return;
+
+  const sel = gamesAll.find(g => g.id === selectedId) || null;
+  if (!sel) {
+    setButtonsState({ hasSel: false, canEdit: false, canPlay: false, canPoll: false, canExport: false });
+    return;
+  }
+
+  // 1) Spróbuj z cache natychmiast (jeśli rev się zgadza)
+  const revHint = sel.updated_at ? String(sel.updated_at) : "";
+  const cached = actionStateCache.get(sel.id);
+  if (cached && revHint && String(cached.rev) === revHint) {
+    
+    const edit = canEnterEdit(normalizeGameForValidate(sel));
+    const canEdit = !!edit.ok;
+    
+    setButtonsState({
+      hasSel: true,
+      canEdit,
+      canPlay: !!cached.res.canPlay,
+      canPoll: !!cached.res.canPoll,
+      canExport: !!cached.res.canExport
+    });
+    return;
+  }
+
+  // 2) Jedno RPC (szybkie)
+  try {
+    const st = await fetchActionState(sel.id, revHint);
+
+    // canEdit zostaje wg Twojej logiki JS (bo masz dokładniejsze komunikaty / warningi)
+    const edit = canEnterEdit(normalizeGameForValidate(sel));
+    const canEdit = !!edit.ok;
+
+    setButtonsState({
+      hasSel: true,
+      canEdit,
+      canPlay: !!st.canPlay,
+      canPoll: !!st.canPoll,
+      canExport: !!st.canExport
+    });
+  } catch (e) {
+    console.error("[builder] game_action_state error:", e);
+    setButtonsState({ hasSel: true, canEdit: false, canPlay: false, canPoll: false, canExport: false });
+  }
+}
+
+
+/* ================= Import/Export ================= */
+async function readFileAsText(file) {
+  return await new Promise((resolve, reject) => {
+    const r = new FileReader();
+    r.onload = () => resolve(String(r.result || ""));
+    r.onerror = () => reject(new Error(MSG.importLoadFailed()));
+    r.readAsText(file);
+  });
+}
+
+/* ================= Main ================= */
+async function refresh() {
+  gamesAll = await listGames();
+
+  if (selectedId && !gamesAll.some(g => g.id === selectedId)) selectedId = null;
+
+  if (activeTab === TYPES.MARKET) {
+    await loadMarketGames();
+    if (selectedMarketId && !marketGamesAll.some(g => g.market_game_id === selectedMarketId)) selectedMarketId = null;
+  }
+
+  render();
+  await updateActionState();
+}
+
+document.addEventListener("DOMContentLoaded", async () => {
+  await initI18n({ withSwitcher: true });
+  initRatingSystem();
+
+  // Blokuj autoInitTopbarAuthButton — builder wywołuje setTopbarAccount z withAccountSettings:true
+  const _btnLogoutEl = document.getElementById('btnLogout');
+  if (_btnLogoutEl) _btnLogoutEl.dataset.topbarAuthReady = '1';
+
+  const { recalc: _navRecalc } = setTopbarNavPriority(
+    () => [
+      document.getElementById('btnMarketplace'),
+      document.getElementById('btnLogoEditor'),
+      document.getElementById('btnBases'),
+      document.getElementById('btnPollsHub'),
+      document.getElementById('btnSubscriptionsHub'),
+      document.getElementById('btnConnectDevice'),
+    ],
+    {
+      moreEl: document.getElementById('navMore'),
+      moreDropdownEl: document.getElementById('navMoreDropdown'),
+    }
+  );
+
+  currentUser = await requireAuth("login");
+  const guestMode = isGuestUser(currentUser);
+  
+  await maybeShowGuestInfoModal(currentUser);
+  
+  if (hideForGuest(currentUser, [btnPollsHub, btnSubscriptionsHub])) {
+    // data-nav-hidden prevents recalc() from resetting display on these buttons
+    if (btnPollsHub) btnPollsHub.dataset.navHidden = "true";
+    if (btnSubscriptionsHub) btnSubscriptionsHub.dataset.navHidden = "true";
+  }
+
+  setTopbarAccount(currentUser, { withAccountSettings: true });
+
+  // btnInstall: widoczny gdy pwa:installable odpalił (canInstall) lub iOS Safari — nie standalone
+  if (btnInstall) {
+    if (isStandalone()) {
+      btnInstall.style.display = "none";
+    } else if (pwaApi.canInstall() || isIOSSafari()) {
+      btnInstall.style.display = "";
+    }
+    // Inaczej zostaje ukryty (Firefox, Safari desktop, lub Chrome zanim odpali beforeinstallprompt)
+  }
+
+  void maybeShowIosWebappPrompt();
+
+  // Android/Chrome/Edge/desktop – auto-prompt instalacji PWA (po odrzuceniu LS_KEY jest set → nie odpali)
+  window.addEventListener("pwa:installable", () => {
+    if (btnInstall && !isStandalone()) btnInstall.style.display = "";
+    if (!localStorage.getItem("pwa:install_dismissed")) showPwaPrompt();
+  }, { once: true });
+  if (pwaApi.canInstall() && !localStorage.getItem("pwa:install_dismissed")) showPwaPrompt();
+
+  async function showPwaPrompt() {
+    if (isStandalone()) return;
+    const ok = await confirmModal({
+      title: t("builder.pwaInstall.title") || "Zainstaluj aplikację",
+      text: t("builder.pwaInstall.text") || "Dodaj Familiadę do ekranu głównego, żeby mieć szybki dostęp.",
+      okText: t("builder.pwaInstall.ok") || "Zainstaluj",
+      cancelText: t("builder.pwaInstall.cancel") || "Nie pokazuj",
+    });
+    if (ok) await pwaApi.install();
+    else pwaApi.dismiss();
+  }
+
+  // btnInstall — klik
+  btnInstall?.addEventListener("click", async () => {
+    if (!pwaApi.canInstall()) {
+      if (isIOSSafari()) {
+        // iOS: pokaż instrukcję dodania do ekranu głównego
+        const fallback = {
+          title: "Dodaj Familiadę do ekranu głównego",
+          text:
+            "Dla najlepszego komfortu użytkowania zalecamy korzystać z aplikacji webowej. Żeby to zrobić:\n" +
+            "1. Otwórz menu Udostępnij.\n" +
+            "2. Wybierz \u201eDo ekranu początkowego\u201d.\n" +
+            "3. Zatwierdź dodanie.\n" +
+            "4. Uruchom Familiadę z nowej ikony na ekranie głównym.",
+          ok: "OK",
+        };
+        await alertModal({
+          title: tSafe("builder.iosWebapp.title", fallback.title),
+          text: tSafe("builder.iosWebapp.text", fallback.text),
+          okText: tSafe("builder.iosWebapp.ok", fallback.ok),
+        });
+      } else {
+        // Chrome/Edge: beforeinstallprompt jeszcze nie odpalił lub app już zainstalowana
+        // Pokaż instrukcję ręcznej instalacji
+        const fallback = {
+          title: "Zainstaluj aplikację",
+          text:
+            "Przeglądarka nie pozwala obecnie na automatyczną instalację.\n\n" +
+            "Możesz zainstalować ręcznie:\n" +
+            "• Chrome/Edge: kliknij ikonę instalacji w pasku adresu i wybierz \"Zainstaluj\"\n" +
+            "• Lub: Menu → Zainstaluj Familiadę",
+          ok: "OK",
+        };
+        await alertModal({
+          title: tSafe("builder.pwaInstall.title", fallback.title),
+          text: tSafe("builder.pwaInstall.manual", fallback.text),
+          okText: tSafe("builder.pwaInstall.ok", fallback.ok),
+        });
+        return;
+      }
+      return;
+    }
+    const ok = await confirmModal({
+      title: t("builder.pwaInstall.title") || "Zainstaluj aplikację",
+      text: t("builder.pwaInstall.text") || "Dodaj Familiadę do ekranu głównego, żeby mieć szybki dostęp.",
+      okText: t("builder.pwaInstall.ok") || "Zainstaluj",
+      cancelText: t("builder.pwaInstall.cancelBtn") || "Anuluj",
+    });
+    if (ok) await pwaApi.install();
+    // Klik Anuluj nie ustawia LS_KEY — celowo bez pwaApi.dismiss()
+  });
+
+  // Przycisk "Podłącz urządzenie":
+  // - desktop/TV: zawsze widoczny
+  // - mobile/tablet: tylko w webapp (standalone)
+  const showConnectDevice = !guestMode && (!isMobileDevice() || isStandalone());
+  if (showConnectDevice) {
+    // Usuń data-nav-hidden żeby overflow nav wiedział że ten przycisk jest aktywny
+    if (btnConnectDevice) {
+      delete btnConnectDevice.dataset.navHidden;
+      btnConnectDevice.style.display = "";
+    }
+
+    async function refreshConnectDeviceBadge() {
+      try {
+        const { data } = await sb().rpc("list_shared_devices_for_me");
+        const n = (data || []).length;
+        if (connectDeviceBadge) {
+          connectDeviceBadge.textContent = n > 0 ? (n > 99 ? "99+" : String(n)) : "";
+          btnConnectDevice?.classList.toggle("has-badge", n > 0);
+        }
+      } catch {}
+    }
+    void refreshConnectDeviceBadge();
+
+    btnConnectDevice?.addEventListener("click", () => {
+      location.href = "connect-device";
+    });
+  } else {
+    // Ukryj przez data-nav-hidden (overflow nav ignoruje takie przyciski)
+    if (btnConnectDevice) {
+      btnConnectDevice.dataset.navHidden = "true";
+      btnConnectDevice.style.display = "none";
+    }
+  }
+
+  // Po ustaleniu widoczności btnConnectDevice przelicz overflow nav
+  requestAnimationFrame(() => _navRecalc?.());
+
+  async function refreshPollsHubDot(){
+    // dot ma się pokazać, gdy są aktywne zadania / zaproszenia
+    try{
+      const { data, error } = await sb().rpc("polls_badge_get");
+      if (error) throw error;
+  
+      const row = Array.isArray(data) ? data[0] : data;
+      const tasks = Number(row?.tasks_pending ?? 0);
+      const invites = Number(row?.subs_pending ?? 0);
+      const pollsText = tasks > 99 ? "99+" : String(tasks);
+      const subsText = invites > 99 ? "99+" : String(invites);
+      btnPollsHub?.classList.toggle("has-badge", tasks > 0);
+      if (pollsHubBadge) pollsHubBadge.textContent = tasks > 0 ? pollsText : "";
+      btnSubscriptionsHub?.classList.toggle("has-badge", invites > 0);
+      if (subscriptionsHubBadge) subscriptionsHubBadge.textContent = invites > 0 ? subsText : "";
+    } catch (e){
+      // jak RPC nie istnieje / nie zwróci pól — nie blokujemy UI
+      btnPollsHub?.classList.remove("has-badge");
+      if (pollsHubBadge) pollsHubBadge.textContent = "";
+      btnSubscriptionsHub?.classList.remove("has-badge");
+      if (subscriptionsHubBadge) subscriptionsHubBadge.textContent = "";
+    }
+  }
+  
+  async function refreshBasesBadge(){
+    try{
+      const { data: cnt, error } = await sb().rpc("bases_count_incoming_share_invites");
+      if (error) throw error;
+  
+      const n = Number(cnt || 0);
+      const el = document.getElementById("basesBadge");
+      const btn = document.getElementById("btnBases");
+  
+      if (!el || !btn) return;
+  
+      if (n > 0){
+        el.textContent = n > 99 ? "99+" : String(n);
+        btn.classList.add("has-badge");
+      } else {
+        el.textContent = "";
+        btn.classList.remove("has-badge");
+      }
+    } catch {
+      // cicho, UI ma działać dalej
+    }
+  }
+  
+
+  let badgesRefreshInFlight = null;
+  let badgesRefreshTimer = null;
+  let lastBadgesRefreshAt = 0;
+
+  async function refreshBadgesNow(){
+    if (badgesRefreshInFlight) return badgesRefreshInFlight;
+    badgesRefreshInFlight = (async () => {
+      await Promise.allSettled([refreshPollsHubDot(), refreshBasesBadge()]);
+      lastBadgesRefreshAt = Date.now();
+    })();
+    try {
+      await badgesRefreshInFlight;
+    } finally {
+      badgesRefreshInFlight = null;
+    }
+  }
+
+  function refreshBadges({ force = false } = {}) {
+    const now = Date.now();
+    const minGapMs = 12_000;
+
+    if (!force && now - lastBadgesRefreshAt < minGapMs) {
+      if (badgesRefreshTimer) return;
+      badgesRefreshTimer = setTimeout(() => {
+        badgesRefreshTimer = null;
+        void refreshBadgesNow();
+      }, minGapMs - (now - lastBadgesRefreshAt));
+      return;
+    }
+
+    if (badgesRefreshTimer) {
+      clearTimeout(badgesRefreshTimer);
+      badgesRefreshTimer = null;
+    }
+
+    void refreshBadgesNow();
+  }
+
+  // po init/requireAuth:
+  refreshBadges({ force: true });
+
+  setInterval(() => {
+    if (document.visibilityState !== "visible") return;
+    refreshBadges();
+  }, 15_000);
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") refreshBadges({ force: true });
+  });
+
+
+  // btnManual
+  btnManual?.addEventListener("click", async () => {
+    const url = new URL("manual", location.href);
+    const ret = `${location.pathname.split("/").pop() || ""}${location.search}${location.hash}`;
+    url.searchParams.set("ret", ret);
+    url.hash = "general";
+    location.href = url.toString();
+  });
+
+  btnLogoEditor?.addEventListener("click", async () => {
+    location.href = "./logo-editor";
+  });
+  
+  btnBases?.addEventListener("click", async () => {
+    location.href = "bases?from=builder";
+  });
+
+  btnPollsHub?.addEventListener("click", () => {
+    location.href = "polls-hub?from=builder";
+  });
+
+  btnSubscriptionsHub?.addEventListener("click", () => {
+    location.href = "subscriptions?from=builder";
+  });
+
+  tabPollText?.addEventListener("click", () => setActiveTab(TYPES.POLL_TEXT));
+  tabPollPoints?.addEventListener("click", () => setActiveTab(TYPES.POLL_POINTS));
+  tabPrepared?.addEventListener("click", () => setActiveTab(TYPES.PREPARED));
+  tabMarket?.addEventListener("click", async () => {
+    if (activeTab !== TYPES.MARKET) {
+      await loadMarketGames();
+    }
+    setActiveTab(TYPES.MARKET);
+  });
+
+  btnMarketplace?.addEventListener("click", () => {
+    location.href = "marketplace";
+  });
+
+  // PREVIEW
+  const previewOverlay = document.getElementById("previewOverlay");
+  const previewTitle = document.getElementById("previewTitle");
+  const previewQuestions = document.getElementById("previewQuestions");
+  const closePreview = () => { if (previewOverlay) previewOverlay.style.display = "none"; };
+  document.getElementById("btnPreviewClose")?.addEventListener("click", closePreview);
+  document.getElementById("btnPreviewCloseBottom")?.addEventListener("click", closePreview);
+  previewOverlay?.addEventListener("click", e => { if (e.target === previewOverlay) closePreview(); });
+
+  btnPreview?.addEventListener("click", async () => {
+    let gameName = "—";
+    let questions = null; // null = loading, [] = brak
+
+    // Ustal nazwę i źródło danych
+    if (activeTab === TYPES.MARKET && selectedMarketId) {
+      const mg = marketGamesAll.find(g => g.market_game_id === selectedMarketId);
+      if (!mg) return;
+      gameName = mg.title || mg.payload?.game?.name || "—";
+      questions = mg.payload?.questions ?? [];
+    } else if (selectedId) {
+      const g = gamesAll.find(x => x.id === selectedId);
+      gameName = g?.name || "—";
+    } else {
+      return;
+    }
+
+    // Pokaż modal natychmiast z nazwą i "Ładowanie…"
+    if (previewTitle) previewTitle.textContent = gameName;
+    if (previewQuestions) previewQuestions.innerHTML = `<div class="bld-no-q">${t("builder.preview.loading") || "Ładowanie…"}</div>`;
+    if (previewOverlay) previewOverlay.style.display = "";
+
+    // Pobierz pytania jeśli jeszcze nie mamy
+    if (questions === null) {
+      try {
+        const exported = await exportGame(selectedId);
+        questions = exported?.questions ?? [];
+      } catch (e) {
+        console.error("[builder] preview export failed:", e);
+        questions = [];
+      }
+    }
+
+    // Renderuj pytania
+    if (!previewQuestions) return;
+    if (!questions.length) {
+      previewQuestions.innerHTML = `<div class="bld-no-q">${t("builder.preview.noQuestions") || "Brak pytań."}</div>`;
+      return;
+    }
+
+    const esc = s => String(s ?? "").replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
+    const ptsLabel = t("builder.preview.pts") || "pkt";
+    previewQuestions.innerHTML = questions.map((q, i) => {
+      const answers = (q.answers ?? []);
+      const hasPoints = answers.some(a => a.fixed_points != null && a.fixed_points > 0);
+      const answersHtml = answers.map(a =>
+        `<li>${esc(a.text)}${hasPoints ? ` <span class="bld-pts">(${a.fixed_points ?? 0} ${ptsLabel})</span>` : ""}</li>`
+      ).join("");
+      return `<div class="bld-q-block">
+        <div class="bld-q-text">${i + 1}. ${esc(q.text)}</div>
+        ${answersHtml ? `<ul class="bld-q-answers">${answersHtml}</ul>` : ""}
+      </div>`;
+    }).join("");
+  });
+
+  // EDIT
+  btnEdit?.addEventListener("click", async () => {
+    if (!selectedId) return;
+
+    const g = gamesAll.find(x => x.id === selectedId);
+    if (!g) return;
+    
+    const info = canEnterEdit(normalizeGameForValidate(g));
+    if (!info.ok) {
+      void alertModal({ text: info.reason });
+      return;
+    }
+
+    if (info.needsResetWarning) {
+      const ok = await confirmModal({
+        title: t("builder.editAfterPoll.title"),
+        text: t("builder.editAfterPoll.text"),
+        okText: t("builder.editAfterPoll.ok"),
+        cancelText: t("builder.editAfterPoll.cancel"),
+      });
+      if (!ok) return;
+
+      try {
+        await resetPollForEditing(g.id);
+        await refresh();
+      } catch (e) {
+        console.error("[builder] resetPollForEditing error:", e);
+        void alertModal({ text: MSG.alertResetPollFailed() });
+        return;
+      }
+    }
+
+    location.href = `editor?id=${encodeURIComponent(g.id)}`;
+  });
+
+  // PLAY
+  btnPlay?.addEventListener("click", async () => {
+    // Gra z marketu: każdy user ma własną kopię games z własnym UUID
+    if (activeTab === TYPES.MARKET && selectedMarketId) {
+      const mg = marketGamesAll.find(g => g.market_game_id === selectedMarketId);
+      if (!mg) return;
+
+      let gameId = mg.game_id;
+      if (!gameId) {
+        // brak kopii — wywołaj market_add_to_library idempotentnie
+        if (btnPlay) btnPlay.disabled = true;
+        try {
+          const { error } = await sb().rpc("market_add_to_library", {
+            p_market_game_id: selectedMarketId,
+          });
+          if (error) { console.error("[builder] market_add_to_library:", error); return; }
+          await loadMarketGames();
+          gameId = marketGamesAll.find(g => g.market_game_id === selectedMarketId)?.game_id;
+        } finally {
+          if (btnPlay) btnPlay.disabled = false;
+        }
+      }
+
+      if (!gameId) return;
+      location.href = `control?id=${encodeURIComponent(gameId)}`;
+      return;
+    }
+
+    if (!selectedId) return;
+
+    try {
+      const chk = await validateGameReadyToPlay(selectedId);
+      if (!chk.ok) {
+        void alertModal({ text: chk.reason });
+        return;
+      }
+      location.href = `control?id=${encodeURIComponent(selectedId)}`;
+    } catch (e) {
+      console.error(e);
+      void alertModal({ text: MSG.alertCheckFailed() });
+    }
+  });
+
+  // POLLS
+  btnPoll?.addEventListener("click", async () => {
+    if (!selectedId) return;
+
+    try {
+      const g = await loadGameBasic(selectedId);
+
+      const entry = await validatePollEntry(selectedId);
+      if (!entry.ok) {
+        void alertModal({ text: entry.reason });
+        return;
+      }
+
+      if (g.status !== STATUS.POLL_OPEN && g.status !== STATUS.READY) {
+        const chk = await validatePollReadyToOpen(selectedId);
+        if (!chk.ok) {
+          void alertModal({ text: chk.reason });
+          return;
+        }
+      }
+
+      location.href = `polls?id=${encodeURIComponent(selectedId)}&from=builder`;
+    } catch (e) {
+      console.error(e);
+      void alertModal({ text: MSG.alertOpenPollFailed() });
+    }
+  });
+
+  // EXPORT — pobierz dane z paskiem, potem instant download
+  btnExport?.addEventListener("click", async () => {
+    if (!selectedId || btnExport?.disabled) return;
+
+    if (exportJsonSub) exportJsonSub.textContent = MSG.exportJsonSub();
+    show(exportJsonOverlay, true);
+    setProgUi(exportJsonStep, exportJsonCount, exportJsonBar, exportJsonMsg, { step: MSG.exportStart(), i: 0, n: 0, msg: "" });
+    if (btnExport) btnExport.disabled = true;
+
+    try {
+      const obj = await exportGame(selectedId, ({ step, i, n, msg } = {}) => {
+        setProgUi(exportJsonStep, exportJsonCount, exportJsonBar, exportJsonMsg, { step: step || MSG.exportFetch(), i, n, msg });
+      });
+      downloadJson(safeDownloadName(obj?.game?.name), obj);
+      show(exportJsonOverlay, false);
+    } catch (e) {
+      console.error(e);
+      setProgUi(exportJsonStep, exportJsonCount, exportJsonBar, exportJsonMsg, {
+        step: MSG.exportErrorLabel(), i: 0, n: 1, msg: e?.message || MSG.exportFailed(), isError: true,
+      });
+      setTimeout(() => show(exportJsonOverlay, false), 1200);
+    } finally {
+      if (btnExport) btnExport.disabled = false;
+    }
+  });
+
+  btnExportBase?.addEventListener("click", async () => {
+    if (!selectedId) return;
+
+    try {
+      setExportBaseMsg("");
+      openExportBaseModal();
+
+      const bases = await listExportableBases();
+      renderBaseSelect(bases);
+    } catch (e) {
+      console.error(e);
+      setExportBaseMsg(MSG.exportBaseLoadFailed());
+    }
+  });
+
+  btnExportBaseCancel?.addEventListener("click", () => closeExportBaseModal());
+
+  btnExportBaseDo?.addEventListener("click", async () => {
+    const baseId = getSelectedBaseId();
+    if (!baseId) {
+      setExportBaseMsg(MSG.exportBasePick());
+      return;
+    }
+  
+    if (btnExportBaseDo?.disabled) return;
+  
+    setExportBaseMsg("");
+    showProgBlock(exportBaseProg, true);
+    setProgUi(exportBaseProgStep, exportBaseProgCount, exportBaseProgBar, exportBaseProgMsg, {
+      step: MSG.exportBaseStart(),
+      i: 0,
+      n: 1,
+      msg: "",
+    });
+  
+    if (btnExportBaseDo) btnExportBaseDo.disabled = true;
+    if (btnExportBaseCancel) btnExportBaseCancel.disabled = true;
+  
+    try {
+      await exportSelectedGameToBase(baseId, ({ step, i, n, msg, isError } = {}) => {
+        setProgUi(exportBaseProgStep, exportBaseProgCount, exportBaseProgBar, exportBaseProgMsg, {
+          step: step || MSG.exportBaseStep(),
+          i,
+          n,
+          msg,
+          isError,
+        });
+      });
+  
+      setProgUi(exportBaseProgStep, exportBaseProgCount, exportBaseProgBar, exportBaseProgMsg, {
+        step: MSG.exportBaseDone(),
+        i: 1,
+        n: 1,
+        msg: MSG.exportBaseSaved(),
+      });
+  
+      closeExportBaseModal();
+      void alertModal({ text: MSG.exportBaseSaved() });
+    } catch (e) {
+      console.error(e);
+      setExportBaseMsg(MSG.exportBaseFailed());
+      setProgUi(exportBaseProgStep, exportBaseProgCount, exportBaseProgBar, exportBaseProgMsg, {
+        step: MSG.exportBaseErrorLabel(),
+        i: 0,
+        n: 1,
+        msg: e?.message || MSG.exportBaseFailed(),
+        isError: true,
+      });
+    } finally {
+      showProgBlock(exportBaseProg, false);
+      if (btnExportBaseDo) btnExportBaseDo.disabled = false;
+      if (btnExportBaseCancel) btnExportBaseCancel.disabled = false;
+    }
+  });
+
+  exportBaseOverlay?.addEventListener("click", (e) => {
+    if (e.target !== exportBaseOverlay) return;
+    closeExportBaseModal();
+  });
+
+
+  // IMPORT (modal)
+  btnImport?.addEventListener("click", openImportModal);
+  btnCancelImport?.addEventListener("click", closeImportModal);
+
+  // RENAME (modal)
+  btnNameCancel?.addEventListener("click", closeRenameModal);
+  nameOverlay?.addEventListener("click", (ev) => { if (ev.target === nameOverlay) closeRenameModal(); });
+  btnNameOk?.addEventListener("click", async () => {
+    if (btnNameOk?.disabled) return;
+    const val = String(nameInp?.value || "").trim();
+    if (!val) return;
+
+    if (btnNameOk) btnNameOk.disabled = true;
+    setNameMsg("");
+
+    try {
+      if (nameMode === "create") {
+        const g = await createGame(creatingUiType, val);
+        selectedId = g.id;
+      } else {
+        if (!renamingGameId) return;
+        await renameGame(renamingGameId, val);
+      }
+      await refresh();
+      closeRenameModal();
+    } catch (e) {
+      console.error("[builder] name modal error:", e);
+      setNameMsg(t("builder.nameModal.failed"));
+    } finally {
+      if (btnNameOk) btnNameOk.disabled = false;
+    }
+  });
+  nameInp?.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      btnNameOk?.click();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      closeRenameModal();
+    }
+  });
+
+  // Wczytanie pliku → podgląd w modalu
+  importFile?.addEventListener("change", async () => {
+    importResetPreview();
+    const f = importFile?.files?.[0];
+    if (!f) return;
+    try {
+      const obj = JSON.parse(await readFileAsText(f));
+      if (!obj?.game || !Array.isArray(obj?.questions)) throw new Error(MSG.importInvalidJson());
+      importParsed = obj;
+      const gameName = obj.game.name || "—";
+      const gameType = typeLabel(uiTypeFromRow({ type: obj.game.type }));
+      const qs = obj.questions;
+
+      const qRows = qs.map((q, i) => {
+        const answers = Array.isArray(q.answers) ? q.answers : [];
+        const hasPoints = answers.some(a => Number(a.fixed_points) > 0);
+        const aHtml = answers.length
+          ? `<div style="margin-top:3px;display:grid;gap:2px;padding-left:10px">` +
+            answers.map(a =>
+              `<div style="opacity:.8;font-size:.8rem">${escapeHtml(String(a.text || ""))}${hasPoints ? ` <span style="opacity:.55">(${Number(a.fixed_points)||0})</span>` : ""}</div>`
+            ).join("") + `</div>`
+          : "";
+        return `<div style="padding:4px 0;border-bottom:1px solid rgba(255,255,255,.07)">
+          <div style="font-size:.85rem"><span style="opacity:.45">${i+1}.</span> ${escapeHtml(String(q.text||""))}</div>
+          ${aHtml}
+        </div>`;
+      }).join("");
+
+      if (importPreview) {
+        importPreview.innerHTML = `
+          <div style="display:flex;gap:16px;flex-wrap:wrap;padding-bottom:6px;border-bottom:1px solid rgba(255,255,255,.12)">
+            <span><span style="opacity:.6">${t("builder.import.preview.name")}</span> <strong>${escapeHtml(gameName)}</strong></span>
+            <span><span style="opacity:.6">${t("builder.import.preview.type")}</span> <strong>${escapeHtml(gameType)}</strong></span>
+            <span><span style="opacity:.6">${t("builder.import.preview.questions")}</span> <strong>${qs.length}</strong></span>
+          </div>
+          <div style="max-height:220px;overflow-y:auto;margin-top:4px">${qRows}</div>`;
+        importPreview.style.display = "grid";
+      }
+      if (btnImportJson) btnImportJson.disabled = false;
+    } catch (e) {
+      if (importErr) { importErr.textContent = e?.message || MSG.importInvalidJson(); importErr.style.display = ""; }
+    }
+  });
+
+  btnImportJson?.addEventListener("click", async () => {
+    if (btnImportJson?.disabled || !importParsed) return;
+    const obj = importParsed;
+    const qCount = Array.isArray(obj?.questions) ? obj.questions.length : 0;
+
+    setImportMsg("");
+    showProgBlock(importProg, true);
+    setProgUi(importProgStep, importProgCount, importProgBar, importProgMsg, {
+      step: MSG.importStart(), i: 0, n: qCount, msg: "",
+    });
+    if (btnImportJson) btnImportJson.disabled = true;
+    if (btnCancelImport) btnCancelImport.disabled = true;
+    if (importFile) importFile.disabled = true;
+
+    try {
+      const newId = await importGame(obj, currentUser.id, ({ step, i, n, msg, isError } = {}) => {
+        setProgUi(importProgStep, importProgCount, importProgBar, importProgMsg, { step: step || MSG.importSave(), i, n, msg, isError });
+      });
+      setProgUi(importProgStep, importProgCount, importProgBar, importProgMsg, {
+        step: MSG.importDone(), i: qCount, n: qCount, msg: MSG.importDone(),
+      });
+      selectedId = newId;
+      try { const ng = await loadGameBasic(newId); if (ng?.type) setActiveTab(uiTypeFromRow(ng)); } catch {}
+      await refresh();
+      closeImportModal();
+    } catch (e) {
+      console.error("IMPORT ERROR:", e);
+      setProgUi(importProgStep, importProgCount, importProgBar, importProgMsg, {
+        step: MSG.importErrorLabel(), i: 0, n: qCount, msg: e?.message || MSG.importFailed(), isError: true,
+      });
+      setImportMsg(MSG.importDbFailed());
+    } finally {
+      showProgBlock(importProg, false);
+      if (btnImportJson) btnImportJson.disabled = !importParsed;
+      if (btnCancelImport) btnCancelImport.disabled = false;
+      if (importFile) importFile.disabled = false;
+    }
+  });
+
+
+  // init — ?tab=market otwiera zakładkę Społeczność od razu
+  const initTab = new URLSearchParams(location.search).get("tab");
+  setActiveTab(initTab === "market" ? TYPES.MARKET : TYPES.PREPARED);
+
+  await refresh();
+
+  // File Handlers API – otwórz modal importu gdy plik został przekazany przez system
+  if ("launchQueue" in window) {
+    window.launchQueue.setConsumer(async (launchParams) => {
+      if (!launchParams.files?.length) return;
+      const file = await launchParams.files[0].getFile();
+      // Wstaw plik do inputu i otwórz modal
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      if (importFile) {
+        importFile.files = dt.files;
+        importFile.dispatchEvent(new Event("change"));
+      }
+      openImportModal();
+    });
+  }
+
+  // auto refresh jak w polls-hub
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden) stopAutoRefresh();
+    else startAutoRefresh();
+  });
+  startAutoRefresh();
+});

--- a/plan-game-settings.md
+++ b/plan-game-settings.md
@@ -1,0 +1,521 @@
+# Plan: Per-game Settings (game-settings)
+
+## Zakres wdrożenia
+Zmiany tylko w `builder-new.html` / `builder-new.js` i `control-new.html` / `control-new/js/app.js`.
+Nowa strona: `game-settings.html` + `game-settings/`.
+
+---
+
+## Struktura plików
+
+```
+familiada/
+├── game-settings.html                  # nowa strona
+├── game-settings/
+│   ├── settings.css                    # style sidebar + content + preview
+│   └── js/
+│       └── app.js                      # logika strony ustawień
+├── js/core/
+│   └── game-settings.js               # load/save/defaults — moduł współdzielony
+└── supabase/migrations/
+    └── 2026-06-05_NNN_game_settings.sql
+```
+
+Modyfikowane:
+```
+builder-new.js                          # przycisk ⚙ na kartach gier
+control-new.html                        # uproszczony flow
+control-new/js/app.js                   # ładuje settings na starcie
+js/core/sfx-new.js                      # klucz IndexedDB: gameId:key
+translation/pl.js, en.js, uk.js         # nowe klucze
+```
+
+---
+
+## Migracja bazy
+
+```sql
+-- supabase/migrations/2026-06-05_NNN_game_settings.sql
+
+ALTER TABLE games
+  ADD COLUMN IF NOT EXISTS settings JSONB NOT NULL DEFAULT '{}';
+
+COMMENT ON COLUMN games.settings IS
+  'Per-game settings: teams, display, sound, questions';
+```
+
+Odczyt zawsze merguje z `getDefaults(locale)`, więc `{}` jest bezpieczne dla istniejących gier.
+
+---
+
+## Struktura danych settings
+
+```jsonc
+{
+  "teams": {
+    "nameA": "Drużyna A",   // locale-dependent default
+    "nameB": "Drużyna B"
+  },
+  "display": {
+    "logoId": null,          // null = domyślne logo z JSON; jeśli ID wskazuje usunięte → fallback do JSON
+    "frameMode": "classic"   // "classic" | "minimal"
+  },
+  "sound": {
+    "volumes": {             // 0–100 (int)
+      "show_intro": 100,
+      "round_transition": 100,
+      "round_transition2": 100,
+      "final_theme": 100,
+      "buzzer_press": 100,
+      "answer_correct": 100,
+      "answer_wrong": 100,
+      "answer_repeat": 100,
+      "time_over": 100,
+      "bells": 100
+    },
+    "variants": {},          // {} = wszystko "classic"; { "buzzer_press": "custom" }
+    "cloudSave": false
+  },
+  "questions": {
+    "mode": "random",        // "random" | "ordered"
+    "count": 3,              // ile pytań losowych per runda (tylko gdy random)
+    "selectedIds": [],       // kolejność pytań (tylko gdy ordered); [] = wszystkie po kolei
+    "roundsCount": 3,        // liczba rund (random: maks; ordered: = len(selectedIds))
+    "finaleMode": "random",  // "random" | "selected"
+    "finaleCount": 5,        // ile pytań finałowych z puli (tylko gdy finaleMode=random)
+    "finaleIds": []          // konkretne pytania do finału (tylko gdy finaleMode=selected)
+  }
+}
+```
+
+---
+
+## Moduł `js/core/game-settings.js`
+
+```js
+// API:
+export async function loadSettings(gameId)
+// Pobiera games.settings z Supabase, merguje z getDefaults(locale)
+// Zwraca: pełny obiekt settings
+
+export async function saveSettings(gameId, settings)
+// Zapisuje settings do games.settings w Supabase
+// Zwraca: { error } | { data }
+
+export function getDefaults(locale)
+// locale: "pl" | "en" | "uk"
+// Zwraca domyślny obiekt settings z lokalnymi nazwami drużyn
+
+export function mergeWithDefaults(partial, locale)
+// Deep merge partial z getDefaults — używane przy odczycie
+
+export async function resolveLogoUrl(logoId, userId)
+// logoId null      → URL z domyślnego logo JSON
+// logoId istnieje  → URL z user_logos
+// logoId usunięte  → URL z domyślnego logo JSON (fallback)
+```
+
+---
+
+## Strona `game-settings.html`
+
+### Topbar
+```
+[← Builder]   Ustawienia: {nazwa gry}   [● Niezapisane]  [Zapisz wszystko]
+```
+- `← Builder` → `builder-new?` lub `history.back()`
+- `● Niezapisane` badge: pojawia się gdy `isDirty === true`; klik scrolluje do paska dolnego
+- `Zapisz wszystko` → jeden `saveSettings()` dla wszystkich kategorii
+
+### Layout (desktop-only, jak control)
+```
+┌─────────────────────────────────────────────────────────────┐
+│  TOPBAR                                                      │
+├─────────────────┬───────────────────────────────────────────┤
+│  SIDEBAR        │  CONTENT AREA (scroll wewnętrzny)         │
+│  (fixed, 200px) │                                           │
+│                 │  [aktywna kategoria]                       │
+│  ┌───────────┐  │                                           │
+│  │ Drużyny   │  │                                           │
+│  └───────────┘  │                                           │
+│  ┌───────────┐  │                                           │
+│  │ Wygląd    │  │                                           │
+│  └───────────┘  │                                           │
+│  ┌───────────┐  │                                           │
+│  │ Dźwięk    │  │                                           │
+│  └───────────┘  │                                           │
+│  ┌───────────┐  │                                           │
+│  │ Pytania   │  │                                           │
+│  │  · Rundy  │  │                                           │
+│  │  · Finał  │  │                                           │
+│  └───────────┘  │                                           │
+├─────────────────┴───────────────────────────────────────────┤
+│  PASEK DOLNY: [● Masz niezapisane zmiany]    [Zapisz]       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Bez wypustek. Sidebar: karty bez zaokrąglonych narożników kart-zakładek. Aktywna karta w sidebarze ma lewe obramowanie złotem (`border-left: 3px solid var(--gold)`).
+
+### Ostrzeżenie o niezapisaniu
+- `window.onbeforeunload` → przeglądarkowe ostrzeżenie
+- `← Builder` → `confirmModal` z pytaniem o niezapisane zmiany
+
+---
+
+## Kategoria: Drużyny
+
+### UI
+```
+┌─────────────────────────────────────────┐
+│  Drużyny                                │
+│                                         │
+│  Drużyna A:  [________________]         │
+│  Drużyna B:  [________________]         │
+│                                         │
+│  [Przywróć domyślne]                    │
+└─────────────────────────────────────────┘
+```
+- Input: `maxlength=30`
+- "Przywróć domyślne" → wczytuje z `getDefaults(locale).teams`
+
+---
+
+## Kategoria: Wygląd
+
+### UI — dwie kolumny
+```
+┌──────────────────────────┬──────────────────────┐
+│  Ustawienia              │  Podgląd wyświetlacza │
+│                          │  ┌────────────────┐   │
+│  Logo:                   │  │ ┌──┐  PYTANIE  │   │
+│  [ui-select: lista logo] │  │ │🖼 │  ======== │   │
+│  [Bez logo] [Domyślne]   │  │ └──┘  A: ████  │   │
+│                          │  │       B: ████  │   │
+│  Tryb ramki:             │  │  [Drużyna A] 0 │   │
+│  ○ Klasyczna             │  │  [Drużyna B] 0 │   │
+│  ○ Minimalna             │  └────────────────┘   │
+│                          │  ~320×200px           │
+└──────────────────────────┴──────────────────────┘
+```
+
+**Logo:**
+- Dropdown `ui-select` z miniaturami logo użytkownika
+- Opcja "Domyślne" (wartość `null` → JSON default)
+- Jeśli wybrany logoId zniknął z bazy → automatycznie pokazuje "Domyślne" z informacją
+
+**Podgląd:**
+- `<div class="display-preview">` — statyczny HTML stylizowany jak ekran gry
+- Aktualizuje się live przy każdej zmianie (logo, ramka, nazwy drużyn)
+- Zawiera: logo w rogu, planszę z odpowiedziami (placeholder), paski punktów z nazwami drużyn
+- NIE jest iframe — tylko stylizowany div
+
+**resolveLogoUrl:**
+```
+logoId === null           → defaultLogoJson.url
+logoId w user_logos       → logo.url
+logoId nie istnieje w DB  → defaultLogoJson.url + log warn
+```
+
+---
+
+## Kategoria: Dźwięk
+
+Pełna tabela 10 kategorii. Per-game — IndexedDB klucz: `{gameId}:{sfxKey}`.
+
+### UI (grid 5 kolumn, identyczny układ jak sfx-advanced-section w control-new)
+```
+Opis        | Wariant (dropdown) | ▶ | Głośność    | Plik
+───────────────────────────────────────────────────────────
+Intro show  | [classic      ▾]  | ▶ | ────●──── 80% | [Dodaj plik]
+Przejście   | [własny plik  ▾]  | ▶ | ──●────── 60% | [moj.mp3 ✕]
+...
+```
+
+Przyciski na dole:
+```
+[Przywróć domyślne dźwięki]    □ Zapisz w chmurze    [Zapisz do chmury]
+```
+
+### Zmiana klucza IndexedDB
+- Stara baza: `familiada-sfx` / store: `custom-files` / klucz: `sfxKey`
+- Nowa baza: `familiada-sfx` / store: `custom-files` / klucz: `{gameId}:{sfxKey}`
+- `sfx-new.js` dostaje `gameId` przez `initSfx(gameId)` — wszystkie operacje prefixują klucz
+
+---
+
+## Kategoria: Pytania
+
+### Podsekcja: Rundy
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Pytania do rund                                     │
+│                                                      │
+│  Tryb:  ○ Losowe    ○ Ustalona kolejność             │
+│                                                      │
+│  [JEŚLI LOSOWE]                                      │
+│  Liczba pytań per runda:  [3 ▾]  (1–10)             │
+│  Maksymalna liczba rund:  [3 ▾]  (1–10)             │
+│                                                      │
+│  [JEŚLI USTALONA KOLEJNOŚĆ]                          │
+│  Lista pytań (drag & drop lub numery):               │
+│  ┌──────────────────────────────────────────────┐    │
+│  │ ☰  1. Jak nazywa się...  [↑][↓][✕]          │    │
+│  │ ☰  2. Wymień 5 rzeczy... [↑][↓][✕]          │    │
+│  │ ☰  3. Co robi...         [↑][↓][✕]          │    │
+│  │ [+ Dodaj pytanie z puli]                      │    │
+│  └──────────────────────────────────────────────┘    │
+│  Liczba rund = liczba wybranych pytań               │
+└─────────────────────────────────────────────────────┘
+```
+
+| Klucz | UI | Domyślna |
+|-------|-----|----------|
+| `questions.mode` | Radio: Losowe / Ustalona kolejność | `"random"` |
+| `questions.count` | Select 1–10 | `3` |
+| `questions.roundsCount` | Select 1–10 | `3` |
+| `questions.selectedIds` | Lista z reorder | `[]` |
+
+### Podsekcja: Finał
+
+Widoczna tylko gdy `game.type !== "prepared"` (gry preparowane nie mają finału ankietowego).
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Pytania finałowe                                    │
+│                                                      │
+│  Tryb:  ○ Losowe z puli    ○ Ustalone                │
+│                                                      │
+│  [JEŚLI LOSOWE]                                      │
+│  Liczba pytań finałowych:  [5 ▾]  (1–10)            │
+│                                                      │
+│  [JEŚLI USTALONE]                                    │
+│  ┌──────────────────────────────────────────────┐    │
+│  │ ☰  1. Pytanie finałowe A  [↑][↓][✕]         │    │
+│  │ [+ Dodaj pytanie finałowe]                    │    │
+│  └──────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────┘
+```
+
+| Klucz | UI | Domyślna |
+|-------|-----|----------|
+| `questions.finaleMode` | Radio: Losowe / Ustalone | `"random"` |
+| `questions.finaleCount` | Select 1–10 | `5` |
+| `questions.finaleIds` | Lista z reorder | `[]` |
+
+---
+
+## Zmiany w builder-new.js
+
+### Przycisk Ustawienia na karcie gry
+
+Dodany obok `[Graj]` i `[Ankieta]`:
+```
+[Podgląd] [Edytuj] [Graj] [Ankieta] [⚙ Ustawienia]
+```
+
+Logika widoczności / stanu:
+- Widoczny: zawsze gdy widoczny `[Graj]`
+- `disabled`: gdy gra nie jest grywalna (`canPlay === false`)
+- Klik: `location.href = \`game-settings?id=\${selectedId}\``
+
+---
+
+## Zmiany w control-new (uproszczenie)
+
+### Usunięte kroki
+- Nazwy drużyn (przeniesione do game-settings → Drużyny)
+- Zaawansowane ustawienia dźwięku (przeniesione do game-settings → Dźwięk)
+- Wybór pytań / podsumowanie (przeniesione do game-settings → Pytania)
+
+### Pozostałe kroki
+```
+Krok 1: Urządzenia
+  - QR kod wyświetlacza
+  - QR kod prowadzącego
+  - QR kod buzzera
+
+Krok 2: Dźwięk
+  - Przycisk "🔊 Odblokuj dźwięk"
+  - Status
+
+→ [Rozpocznij grę]
+```
+
+### Startup w control-new/js/app.js
+```js
+// Po requireAuth i pobraniu gameId:
+const settings = await loadSettings(gameId);
+applyTeamNames(settings.teams);
+await initSfx(gameId);  // nowy podpis z gameId
+applyDisplaySettings(settings.display);
+// → gotowy do startu rundy 1
+```
+
+---
+
+## Zmiany w sfx-new.js
+
+```js
+// Stara sygnatura:
+export async function initSfx()
+
+// Nowa:
+export async function initSfx(gameId)
+// gameId przekazywany do wszystkich operacji IndexedDB
+// klucz: `${gameId}:${sfxKey}` zamiast `${sfxKey}`
+
+// Inne funkcje dotknięte:
+setSfxCustomBlob(key, blob, filename, gameId)
+getSfxCustomFiles(gameId)
+clearSfxCustomFile(key, gameId)
+clearAllSfxCustomFiles(gameId)
+```
+
+---
+
+## Tłumaczenia (nowe klucze)
+
+```js
+// translation/pl.js — sekcja "settings":
+settings: {
+  title: "Ustawienia gry",
+  back: "← Builder",
+  saveAll: "Zapisz wszystko",
+  unsaved: "Niezapisane zmiany",
+  unsavedConfirm: "Masz niezapisane zmiany. Czy chcesz opuścić stronę?",
+  saved: "Zapisano",
+  saveError: "Błąd zapisu",
+  categories: {
+    teams: "Drużyny",
+    display: "Wygląd",
+    sound: "Dźwięk",
+    questions: "Pytania",
+    rounds: "Rundy",
+    finale: "Finał",
+  },
+  teams: {
+    nameA: "Nazwa drużyny A",
+    nameB: "Nazwa drużyny B",
+    restoreDefaults: "Przywróć domyślne",
+    defaultA: "Drużyna A",
+    defaultB: "Drużyna B",
+  },
+  display: {
+    logo: "Logo",
+    logoDefault: "Domyślne",
+    logoNone: "Bez logo",
+    logoMissing: "Logo zostało usunięte — używamy domyślnego",
+    frameMode: "Tryb ramki",
+    frameModeClassic: "Klasyczna",
+    frameModeMinimal: "Minimalna",
+    preview: "Podgląd wyświetlacza",
+  },
+  questions: {
+    modeRandom: "Losowe",
+    modeOrdered: "Ustalona kolejność",
+    countPerRound: "Pytań per runda",
+    roundsCount: "Liczba rund",
+    addQuestion: "+ Dodaj pytanie z puli",
+    finaleTitle: "Pytania finałowe",
+    finaleModeRandom: "Losowe z puli",
+    finaleModeSelected: "Ustalone",
+    finaleCount: "Liczba pytań finałowych",
+    addFinaleQuestion: "+ Dodaj pytanie finałowe",
+  },
+}
+```
+
+Analogiczne klucze w `en.js` i `uk.js` z odpowiednimi tłumaczeniami i domyślnymi nazwami drużyn (Team A/B, Команда А/Б).
+
+---
+
+## CSS (`game-settings/settings.css`)
+
+```css
+/* Główny layout */
+.gs-layout {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  grid-template-rows: 1fr auto;  /* content + footer bar */
+  height: calc(100vh - topbar-height);
+  overflow: hidden;
+}
+
+/* Sidebar */
+.gs-sidebar {
+  border-right: 1px solid rgba(255,255,255,.1);
+  padding: 16px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  overflow-y: auto;
+}
+
+.gs-sidebar-item {
+  /* karta bez wypustek */
+  padding: 10px 14px;
+  border-radius: 12px;
+  cursor: pointer;
+  font-size: .9rem;
+  font-weight: 600;
+}
+
+.gs-sidebar-item.active {
+  border-left: 3px solid var(--gold);
+  background: rgba(255,234,166,.08);
+  color: var(--gold);
+}
+
+.gs-sidebar-sub {
+  padding-left: 24px;
+  font-size: .82rem;
+  font-weight: 500;
+  opacity: .75;
+}
+
+/* Content */
+.gs-content {
+  overflow-y: auto;
+  padding: 24px 28px;
+}
+
+/* Footer bar (niezapisane) */
+.gs-footer {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 20px;
+  border-top: 1px solid rgba(255,255,255,.1);
+  background: rgba(255,234,166,.06);
+}
+
+.gs-footer.hidden { display: none; }
+
+/* Podgląd wyświetlacza */
+.display-preview {
+  width: 320px;
+  height: 200px;
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,.2);
+  background: #050914;
+  position: relative;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+```
+
+---
+
+## Kolejność implementacji (proponowana)
+
+1. **Migracja SQL** + moduł `game-settings.js` (load/save/defaults/resolveLogoUrl)
+2. **game-settings.html** — szkielet HTML + CSS layout (sidebar + content)
+3. **Kategoria Drużyny** — najprostsza, dobry smoke test
+4. **Kategoria Wygląd** — logo dropdown + preview div (bez iframe)
+5. **Kategoria Dźwięk** — port z sfx-advanced-section + zmiana klucza IndexedDB w sfx-new.js
+6. **Kategoria Pytania** — Rundy + Finał (najbardziej złożona)
+7. **Zapis + dirty tracking** — `isDirty`, `beforeunload`, pasek dolny
+8. **builder-new.js** — przycisk ⚙ na kartach
+9. **control-new** — usunięcie kroków + `loadSettings` na starcie

--- a/plan-game-settings.md
+++ b/plan-game-settings.md
@@ -339,8 +339,42 @@ Krok 2: Dźwięk
   - Przycisk "🔊 Odblokuj dźwięk"
   - Status
 
+Krok 3: Podsumowanie ustawień
+  - Wszystkie kategorie na jednej karcie, same opisy (bez edycji)
+  - [link: Zmień ustawienia → game-settings?id=...]
+
 → [Rozpocznij grę]
 ```
+
+### Krok 3 — szczegóły UI
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Ustawienia gry                                      │
+│                                                      │
+│  [⚠ Używasz domyślnych ustawień — rozważ konfigurację]  ← tylko gdy isDefault
+│                                                      │
+│  Drużyny       Drużyna A vs Drużyna B               │
+│  Wygląd        Motyw: classic, Logo: domyślne        │
+│  Dźwięk        Głośności domyślne, brak plików       │
+│  Pytania       Finał: losowe · Rundy: losowe         │
+│  Rozgrywka     Finał: tak · Mnożniki: 1,1,1,2,3     │
+│                                                      │
+│  Pytania rund:                                       │
+│  (wszystkie — kolejność losowa)                      │
+│                                                      │
+│  Pytania finału:                                     │
+│  (wylosowane przy starcie finału)                    │
+│                                                      │
+│                          [⚙ Zmień ustawienia]       │
+└─────────────────────────────────────────────────────┘
+```
+
+- Każda kategoria: jedna linia z najważniejszymi wartościami
+- Pytania: streszczenie takie jak obecne `summaryRoundsQuestions` / `summaryFinalQuestions` w control
+- `isDefault === true` → żółty badge ostrzegawczy u góry (nie blokuje startu)
+- `[⚙ Zmień ustawienia]` → `location.href = \`game-settings?id=\${gameId}\``
+- Dane ze `settings` załadowanych przy starcie control — nie wymaga dodatkowego fetch
 
 ### Startup w control-new/js/app.js
 ```js

--- a/plan-game-settings.md
+++ b/plan-game-settings.md
@@ -307,6 +307,21 @@ Widoczna tylko gdy `game.type !== "prepared"` (gry preparowane nie mają finału
 
 ## Zmiany w builder-new.js
 
+### Kolejność przycisków topbaru
+
+W oryginale (`builder.html`) nawigacja topbaru ma kolejność:
+```
+Logo → Bazy → PollsHub → SubscriptionsHub → Podłącz urządzenie
+```
+
+W `builder-new.html` zmieniamy kolejność — **Podłącz urządzenie bezpośrednio po Bazy**:
+```
+Logo → Bazy → Podłącz urządzenie → PollsHub → SubscriptionsHub
+```
+
+Zmiana tylko w HTML (`builder-new.html`) — przestawienie kolejności elementów DOM.
+Logika widoczności `btnConnectDevice` (pokazuje się po zalogowaniu) pozostaje bez zmian.
+
 ### Przycisk Ustawienia na karcie gry
 
 Dodany obok `[Graj]` i `[Ankieta]`:

--- a/translation/en.js
+++ b/translation/en.js
@@ -4983,6 +4983,7 @@ const en = {
     sfxSaveCloud: "Save to cloud",
     sfxSaveBtn: "Save",
     sfxResetAll: "Restore defaults",
+    sfxResetConfirm: "Restore default sound settings? All custom files and volumes will be removed.",
     sfxTooLongTitle: "File too long",
     sfxTooLong: "Maximum length is {limit}s",
     sfxDesc: {

--- a/translation/pl.js
+++ b/translation/pl.js
@@ -4362,6 +4362,7 @@ const pl = {
     sfxSaveCloud: "Zapisz w chmurze",
     sfxSaveBtn: "Zapisz",
     sfxResetAll: "Przywróć domyślne",
+    sfxResetConfirm: "Przywrócić domyślne ustawienia dźwięku? Wszystkie własne pliki i głośności zostaną usunięte.",
     sfxTooLongTitle: "Plik za długi",
     sfxTooLong: "Maksymalna długość to {limit}s",
     sfxDesc: {

--- a/translation/uk.js
+++ b/translation/uk.js
@@ -4971,6 +4971,7 @@ const uk = {
     sfxSaveCloud: "Зберегти в хмарі",
     sfxSaveBtn: "Зберегти",
     sfxResetAll: "Відновити типові",
+    sfxResetConfirm: "Відновити типові налаштування звуку? Усі власні файли та гучності буде видалено.",
     sfxTooLongTitle: "Файл занадто довгий",
     sfxTooLong: "Максимальна тривалість — {limit}с",
     sfxDesc: {


### PR DESCRIPTION
Dodaje `plan-game-settings.md` — szczegółowy plan implementacji per-game settings (game-settings.html).

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9fT5Zipto4yThm1UQFobs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Polish-language game builder UI with tabs, preview/edit/play controls, import/export flows, rename/delete, and PWA install support.
  * Export-to-base and file export with progress; OS file launches open import modal.

* **Improvements**
  * Reorganized advanced sound settings UI, clearer preview/reset actions and confirmation text.
  * More reliable SFX playback/duration handling and refreshed navigation/tab behavior.

* **Documentation**
  * Plan added for per-game settings (design and integration).

* **Localization**
  * Added SFX reset confirmation text in Polish, English and Ukrainian.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->