### PR TITLE
feat: sfx-new pełna kopia + builder-new kolejność przycisków + plan

### DIFF
--- a/builder-new.html
+++ b/builder-new.html
@@ -2,7 +2,7 @@
 <html lang="pl">
 <head>
   <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate">
-  <meta name="app-version" content="v2026-06-04T22541"/>
+  <meta name="app-version" content="v2026-06-03T21150"/>
 
   <meta charset="UTF-8"/>
   <meta name="robots" content="noindex, nofollow"/>
@@ -12,16 +12,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"/>
   <title data-i18n="builder.title">Familiada — moje gry</title>
 
-  <link rel="icon" href="favicon.ico?v=v2026-06-04T22541"/>
-  <link rel="manifest" href="/manifest.json?v=v2026-06-04T22541"/>
+  <link rel="icon" href="favicon.ico?v=v2026-06-03T21150"/>
+  <link rel="manifest" href="/manifest.json?v=v2026-06-03T21150"/>
   <meta name="theme-color" content="#050914"/>
-  <link rel="stylesheet" href="css/base.css?v=v2026-06-04T22541"/>
-  <link rel="stylesheet" href="css/builder.css?v=v2026-06-04T22541"/>
+  <link rel="stylesheet" href="css/base.css?v=v2026-06-03T21150"/>
+  <link rel="stylesheet" href="css/builder.css?v=v2026-06-03T21150"/>
 
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
-  <script src="js/core/security-warning.js?v=v2026-06-04T22541" defer></script>
-  <script type="module" src="js/pages/builder-new.js?v=v2026-06-04T22541" defer></script>
-  <script type="module" src="js/core/topbar-controller.js?v=v2026-06-04T22541" defer></script>
+  <script src="js/core/security-warning.js?v=v2026-06-03T21150" defer></script>
+  <script type="module" src="js/pages/builder-new.js?v=v2026-06-03T21150" defer></script>
+  <script type="module" src="js/core/topbar-controller.js?v=v2026-06-03T21150" defer></script>
 </head>
 
 <body class="builder-body">
@@ -44,6 +44,11 @@
         <span class="badge" id="basesBadge" aria-hidden="true"></span>
       </button>
 
+      <button class="btn" id="btnConnectDevice" data-nav-hidden="true" style="display:none;">
+        <span data-i18n="builder.nav.connectDevice">Podłącz urządzenie 📱</span>
+        <span class="badge" id="connectDeviceBadge" aria-hidden="true"></span>
+      </button>
+
       <button class="btn" id="btnPollsHub">
         <span data-i18n="builder.nav.pollsHubPolls">Ankiety 📊</span>
         <span class="badge" id="pollsHubBadge" aria-hidden="true"></span>
@@ -52,11 +57,6 @@
       <button class="btn" id="btnSubscriptionsHub">
         <span data-i18n="builder.nav.pollsHubSubs">Subskrypcje 📧</span>
         <span class="badge" id="subscriptionsHubBadge" aria-hidden="true"></span>
-      </button>
-
-      <button class="btn" id="btnConnectDevice" data-nav-hidden="true" style="display:none;">
-        <span data-i18n="builder.nav.connectDevice">Podłącz urządzenie 📱</span>
-        <span class="badge" id="connectDeviceBadge" aria-hidden="true"></span>
       </button>
 
       <div class="nav-more" id="navMore" style="display:none;">

--- a/js/core/sfx-new.js
+++ b/js/core/sfx-new.js
@@ -1,16 +1,17 @@
-// js/core/sfx-new.js — sandbox rozszerzenia sfx.js
-// Dodaje: manifest z audio_new/sounds.json, warianty, głośności, custom blob URL, IndexedDB
+// js/core/sfx-new.js
+// Kopia sfx.js z rozszerzeniami: manifest, warianty, głośności, custom blob, cloud URL.
+// Plik samodzielny — nie importuje sfx.js.
 
-const MANIFEST_PATH = "../audio_new/sounds.json?v=v2026-06-04T22541";
+const MANIFEST_PATH = "../audio_new/sounds.json?v=v2026-06-03T21150";
 const AUDIO_BASE    = "../audio_new/";
 const IDB_NAME      = "familiada-sfx";
 const IDB_STORE     = "custom-files";
 const LS_VOL_PREFIX = "sfx_vol_";
 const LS_VAR_PREFIX = "sfx_variant_";
 
-// ===================== MANIFEST =====================
+/* ========= MANIFEST ========= */
 
-let manifest = null; // tablica categories po załadowaniu
+let manifest = null;
 
 export async function loadSfxManifest() {
   if (manifest) return manifest;
@@ -24,11 +25,15 @@ export function getSfxCategories() {
   return manifest || [];
 }
 
+export function listSfx() {
+  return getSfxCategories().map(c => c.key);
+}
+
 function getCategoryMeta(key) {
   return (manifest || []).find(c => c.key === key) || null;
 }
 
-// ===================== CACHE AUDIO =====================
+/* ========= CACHE AUDIO ========= */
 
 const cache = new Map(); // key → Audio
 
@@ -42,13 +47,14 @@ function loadIntoCache(key, url) {
     try { old.pause(); } catch {}
     if (old.src.startsWith("blob:")) URL.revokeObjectURL(old.src);
   }
+  durationPromises.delete(key);
   const a = new Audio(url);
   a.preload = "auto";
   cache.set(key, a);
   return a;
 }
 
-// ===================== WARIANTY =====================
+/* ========= WARIANTY ========= */
 
 export function getSfxVariant(key) {
   return localStorage.getItem(LS_VAR_PREFIX + key) || "classic.mp3";
@@ -70,7 +76,7 @@ export function resetSfxVariants() {
   }
 }
 
-// ===================== GŁOŚNOŚCI =====================
+/* ========= GŁOŚNOŚCI ========= */
 
 export function getSfxVolume(key) {
   const v = localStorage.getItem(LS_VOL_PREFIX + key);
@@ -111,7 +117,7 @@ export function resetSfxVolumes() {
   }
 }
 
-// ===================== CUSTOM BLOB (IndexedDB) =====================
+/* ========= CUSTOM BLOB (IndexedDB) ========= */
 
 function openIDB() {
   return new Promise((resolve, reject) => {
@@ -158,7 +164,6 @@ export async function clearSfxCustomFile(key) {
   const old = cache.get(key);
   if (old?.src?.startsWith("blob:")) URL.revokeObjectURL(old.src);
 
-  // wróć do aktywnego wariantu
   const meta = getCategoryMeta(key);
   if (meta) {
     loadIntoCache(key, buildUrl(meta.folder, getSfxVariant(key)));
@@ -180,7 +185,7 @@ export async function clearAllSfxCustomFiles() {
   }
 }
 
-// ===================== CLOUD URL =====================
+/* ========= CLOUD URL ========= */
 
 export function loadSfxFromCloud(urlMap) {
   for (const [key, url] of urlMap) {
@@ -189,7 +194,7 @@ export function loadSfxFromCloud(urlMap) {
   }
 }
 
-// ===================== ODTWARZANIE =====================
+/* ========= PROSTE ODTWARZANIE ========= */
 
 export function playSfx(key) {
   const a = cache.get(key);
@@ -200,6 +205,8 @@ export function playSfx(key) {
   } catch {}
 }
 
+/* ========= MIKSER / ŚLEDZENIE CZASU ========= */
+
 export function createSfxMixer() {
   let audio = null;
   let raf = null;
@@ -207,7 +214,9 @@ export function createSfxMixer() {
 
   function notify() {
     if (!audio) return;
-    for (const fn of listeners) fn(audio.currentTime || 0, audio.duration || 0);
+    const t = audio.currentTime || 0;
+    const d = audio.duration || 0;
+    for (const fn of listeners) fn(t, d);
   }
 
   function tick() {
@@ -231,34 +240,41 @@ export function createSfxMixer() {
       audio = null;
     },
     onTime(fn) { listeners.add(fn); return () => listeners.delete(fn); },
-    get time() { return audio?.currentTime || 0; },
+    get time() { return audio ? audio.currentTime : 0; },
     get duration() { return audio?.duration || 0; },
   };
 }
 
-// ===================== INICJALIZACJA =====================
+/* ========= DOKŁADNE MIERZENIE DŁUGOŚCI AUDIO ========= */
+
+const durationPromises = new Map();
 
 /**
- * Wywołać raz przy starcie (po loadSfxManifest):
- * wczytuje zapisane warianty, głośności i custom blobs z IndexedDB
+ * Zwraca Promise z dokładną długością dźwięku w sekundach (float).
+ * Jeśli nie da się odczytać – zwraca 0.
  */
-export async function initSfx() {
-  for (const cat of getSfxCategories()) {
-    const variant = getSfxVariant(cat.key);
-    loadIntoCache(cat.key, buildUrl(cat.folder, variant));
-  }
-  applySfxVolumes();
+export function getSfxDuration(key) {
+  if (durationPromises.has(key)) return durationPromises.get(key);
 
-  // wczytaj custom blobs z IndexedDB
-  const files = await getSfxCustomFiles();
-  for (const [key, { blob }] of files) {
-    const url = URL.createObjectURL(blob);
-    loadIntoCache(key, url);
-    applySfxVolume(key);
+  const a = cache.get(key);
+  if (!a) {
+    const p = Promise.resolve(0);
+    durationPromises.set(key, p);
+    return p;
   }
+
+  const p = new Promise((resolve) => {
+    if (!Number.isNaN(a.duration) && a.duration > 0) { resolve(a.duration); return; }
+    const onMeta = () => { a.removeEventListener("loadedmetadata", onMeta); resolve(a.duration || 0); };
+    a.addEventListener("loadedmetadata", onMeta);
+    setTimeout(() => { a.removeEventListener("loadedmetadata", onMeta); resolve(a.duration || 0); }, 5000);
+  });
+
+  durationPromises.set(key, p);
+  return p;
 }
 
-// ===================== AUDIO UNLOCK =====================
+/* ========= AUDIO UNLOCK (gesture) ========= */
 
 let unlocked = false;
 
@@ -275,3 +291,22 @@ export function unlockAudio() {
 }
 
 export function isAudioUnlocked() { return unlocked; }
+
+/* ========= INICJALIZACJA ========= */
+
+/**
+ * Wywołać raz przy starcie (po loadSfxManifest):
+ * wczytuje zapisane warianty, głośności i custom blobs z IndexedDB.
+ */
+export async function initSfx() {
+  for (const cat of getSfxCategories()) {
+    loadIntoCache(cat.key, buildUrl(cat.folder, getSfxVariant(cat.key)));
+  }
+  applySfxVolumes();
+
+  const customFiles = await getSfxCustomFiles();
+  for (const [key, { blob }] of customFiles) {
+    loadIntoCache(key, URL.createObjectURL(blob));
+    applySfxVolume(key);
+  }
+}

--- a/plan-game-settings.md
+++ b/plan-game-settings.md
@@ -307,6 +307,21 @@ Widoczna tylko gdy `game.type !== "prepared"` (gry preparowane nie mają finału
 
 ## Zmiany w builder-new.js
 
+### Kolejność przycisków topbaru
+
+W oryginale (`builder.html`) nawigacja topbaru ma kolejność:
+```
+Logo → Bazy → PollsHub → SubscriptionsHub → Podłącz urządzenie
+```
+
+W `builder-new.html` zmieniamy kolejność — **Podłącz urządzenie bezpośrednio po Bazy**:
+```
+Logo → Bazy → Podłącz urządzenie → PollsHub → SubscriptionsHub
+```
+
+Zmiana tylko w HTML (`builder-new.html`) — przestawienie kolejności elementów DOM.
+Logika widoczności `btnConnectDevice` (pokazuje się po zalogowaniu) pozostaje bez zmian.
+
 ### Przycisk Ustawienia na karcie gry
 
 Dodany obok `[Graj]` i `[Ankieta]`:
@@ -339,8 +354,42 @@ Krok 2: Dźwięk
   - Przycisk "🔊 Odblokuj dźwięk"
   - Status
 
+Krok 3: Podsumowanie ustawień
+  - Wszystkie kategorie na jednej karcie, same opisy (bez edycji)
+  - [link: Zmień ustawienia → game-settings?id=...]
+
 → [Rozpocznij grę]
 ```
+
+### Krok 3 — szczegóły UI
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Ustawienia gry                                      │
+│                                                      │
+│  [⚠ Używasz domyślnych ustawień — rozważ konfigurację]  ← tylko gdy isDefault
+│                                                      │
+│  Drużyny       Drużyna A vs Drużyna B               │
+│  Wygląd        Motyw: classic, Logo: domyślne        │
+│  Dźwięk        Głośności domyślne, brak plików       │
+│  Pytania       Finał: losowe · Rundy: losowe         │
+│  Rozgrywka     Finał: tak · Mnożniki: 1,1,1,2,3     │
+│                                                      │
+│  Pytania rund:                                       │
+│  (wszystkie — kolejność losowa)                      │
+│                                                      │
+│  Pytania finału:                                     │
+│  (wylosowane przy starcie finału)                    │
+│                                                      │
+│                          [⚙ Zmień ustawienia]       │
+└─────────────────────────────────────────────────────┘
+```
+
+- Każda kategoria: jedna linia z najważniejszymi wartościami
+- Pytania: streszczenie takie jak obecne `summaryRoundsQuestions` / `summaryFinalQuestions` w control
+- `isDefault === true` → żółty badge ostrzegawczy u góry (nie blokuje startu)
+- `[⚙ Zmień ustawienia]` → `location.href = \`game-settings?id=\${gameId}\``
+- Dane ze `settings` załadowanych przy starcie control — nie wymaga dodatkowego fetch
 
 ### Startup w control-new/js/app.js
 ```js


### PR DESCRIPTION
Zastępuje PR #82 (konflikt hashów przy rebase).

## Zmiany

- **sfx-new.js** — pełna samodzielna kopia `sfx.js` z rozszerzeniami (manifest, warianty, głośności, IDB, cloud URL). Eksportuje `listSfx`, `getSfxDuration` i wszystkie funkcje oryginału. Inwalidacja cache duracji przy zmianie wariantu/pliku.
- **builder-new.html** — Podłącz urządzenie przeniesione bezpośrednio po Logo i Bazach
- **plan-game-settings.md** — Krok 3 w control-new (podsumowanie ustawień), ostrzeżenie o domyślnych ustawieniach, zmiana kolejności przycisków topbaru

https://claude.ai/code/session_01H9fT5Zipto4yThm1UQFobs

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9fT5Zipto4yThm1UQFobs)_